### PR TITLE
IPA-3634: Add record size calculation to metrics

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -9,15 +9,22 @@ if(DOXYGEN_FOUND)
     COMMENT "Generating API documentation with Doxygen" VERBATIM
     )
 
-    add_custom_target(deploy-docs
-            COMMAND git checkout gh-pages
-            COMMAND git rm -rf .
-            COMMAND cp -r Build/Debug/html/* ./
-            COMMAND git add .
-            COMMAND git commit -am "Added documentation"
-            COMMAND git push origin gh-pages
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    )
+    if(NOT GIT_FOUND)
+        find_package(Git REQUIRED)
+    endif()
+
+    if(GIT_FOUND AND NOT WIN32) # Don't think this will work on Windows (cp command), so disable for now
+        add_custom_target(deploy-docs
+                COMMAND ${GIT_EXECUTABLE} checkout gh-pages
+                COMMAND ${GIT_EXECUTABLE} rm reset `git rev-list --max-parents=0 --abbrev-commit HEAD` --hard
+                COMMAND cp -r Build/Debug/html/* ./
+                COMMAND ${GIT_EXECUTABLE} add .
+                COMMAND ${GIT_EXECUTABLE} commit -am "Added documentation"
+                COMMAND ${GIT_EXECUTABLE} push origin gh-pages
+                COMMAND ${GIT_EXECUTABLE} checkout @{-1}
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        )
+    endif()
 
 else()
     message(WARNING "Doxygen not found, documentation generation is disabled")

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -839,7 +839,7 @@ EXCLUDE_SYMBOLS        = static_assert_ tile_summary TileSummary Example1 Exampl
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = ../../
+EXAMPLE_PATH           = @PROJECT_SOURCE_DIR@
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/interop/io/format/abstract_metric_format.h
+++ b/interop/io/format/abstract_metric_format.h
@@ -34,8 +34,16 @@ namespace illumina {
                 /** Destructor
                  */
                 virtual ~abstract_metric_format(){}
+
+                /** Calculate the size of the file header
+                 *
+                 * @param header metric set header
+                 * @return size of header in bytes
+                 */
+                virtual size_t header_size(const header_t& header)const=0;
                 /** Calculate the size of a record
                  *
+                 * @param header metric set header
                  * @return size of record in bytes
                  */
                 virtual size_t record_size(const header_t& header)const=0;

--- a/interop/io/format/metric_format.h
+++ b/interop/io/format/metric_format.h
@@ -95,11 +95,21 @@ namespace illumina {
                 }
                 /** Calculate the size of a record
                  *
+                 * @param header metric set header
                  * @return size of record in bytes
                  */
                 size_t record_size(const header_t& header)const
                 {
                     return static_cast<size_t>(Layout::computeSize(header));
+                }
+                /** Calculate the size of a record
+                 *
+                 * @param header metric set header
+                 * @return size of header in bytes
+                 */
+                size_t header_size(const header_t& header)const
+                {
+                    return static_cast<size_t>(Layout::computeHeaderSize(header));
                 }
                 /** Read a metric set from the given input stream
                  *

--- a/interop/io/metric_file_stream.h
+++ b/interop/io/metric_file_stream.h
@@ -23,7 +23,17 @@ namespace io {
 template<class MetricType>
 std::string interop_filename(const std::string& runDirectory, bool useOut = true)
 {
-    return detail::interop_name(runDirectory, MetricType::prefix(), useOut);
+    return detail::interop_filename(runDirectory, MetricType::prefix(), useOut);
+}
+/** Generate a file name from a run directory and the metric type
+ *
+ * @param useOut if true, append "Out" to the end of the filename
+ * @return file path to the InterOp directory
+ */
+template<class MetricType>
+std::string interop_basename(bool useOut = true)
+{
+    return detail::interop_basename(MetricType::prefix(), useOut);
 }
 
 

--- a/interop/io/metric_stream.h
+++ b/interop/io/metric_stream.h
@@ -29,14 +29,22 @@ namespace illumina {
                 }
                 /** Generate a file name from a run directory and the InterOp name
                  *
+                 * @param name name of the interop file
+                 * @param useOut if true, append "Out" to the end of the filename
+                 * @return file path to the InterOp directory
+                 */
+                inline std::string interop_basename(const std::string& name, bool useOut = true) {
+                    return name + "Metrics" + ((useOut) ? ("Out.bin") : (".bin"));
+                }
+                /** Generate a file name from a run directory and the InterOp name
+                 *
                  * @param runDirectory file path to the run directory
                  * @param name name of the interop file
                  * @param useOut if true, append "Out" to the end of the filename
                  * @return file path to the InterOp directory
                  */
-                inline std::string interop_name(const std::string& runDirectory, const std::string& name, bool useOut = true) {
-                    return io::combine(interop_directory_name(runDirectory),
-                                       name + "Metrics" + ((useOut) ? ("Out.bin") : (".bin")));
+                inline std::string interop_filename(const std::string& runDirectory, const std::string& name, bool useOut = true) {
+                    return io::combine(interop_directory_name(runDirectory), interop_basename(name, useOut));
                 }
                 /** Memory buffer for a stream
                  *

--- a/interop/io/metric_stream.h
+++ b/interop/io/metric_stream.h
@@ -137,10 +137,11 @@ namespace illumina {
                     }
                 }
             }
-            /** Write a metric to a binary InterOp file
+            /** Get the size of a single metric record
              *
              * @param header header for metric
              * @param version version of the format
+             * @return size of a single metric record
              */
             template<class MetricType>
             size_t record_size(const typename MetricType::header_type& header, const ::int16_t version = MetricType::LATEST_VERSION)
@@ -156,6 +157,27 @@ namespace illumina {
 
                 assert(format_map[version]);
                 return format_map[version]->record_size(header);
+            }
+            /** Get the size of a metric file header
+             *
+             * @param header header for metric
+             * @param version version of the format
+             * @return size of metric file header
+             */
+            template<class MetricType>
+            size_t header_size(const typename MetricType::header_type& header, const ::int16_t version = MetricType::LATEST_VERSION)
+            {
+                typedef metric_format_factory <MetricType> factory_type;
+                typedef typename factory_type::metric_format_map metric_format_map;
+                metric_format_map& format_map=factory_type::metric_formats();
+
+                if (format_map.find(version) == format_map.end())
+                    throw bad_format_exception("No format found to write file with version: " +
+                                               util::lexical_cast<std::string>(version) + " of " +
+                                               util::lexical_cast<std::string>(format_map.size()));
+
+                assert(format_map[version]);
+                return format_map[version]->header_size(header);
             }
             /** Write a metric to a binary InterOp file
              *

--- a/src/interop/model/metrics/corrected_intensity_metric.cpp
+++ b/src/interop/model/metrics/corrected_intensity_metric.cpp
@@ -109,6 +109,14 @@ namespace illumina{ namespace interop{ namespace io {
                                     sizeof(float)                                       // m_signalToNoise
                     );
                 }
+                /** Compute header size
+                 *
+                 * @return header size
+                 */
+                static record_size_t computeHeaderSize(const corrected_intensity_metric::header_type&)
+                {
+                    return sizeof(record_size_t) + sizeof(::uint8_t);
+                }
             };
             /** Corrected Intensity Metric Record Layout Version 3
              *
@@ -189,6 +197,14 @@ namespace illumina{ namespace interop{ namespace io {
                             sizeof(::uint16_t)*constants::NUM_OF_BASES +        // m_correctedIntCalled
                             sizeof(::uint32_t)*constants::NUM_OF_BASES_AND_NC   // m_calledCounts
                     );
+                }
+                /** Compute header size
+                 *
+                 * @return header size
+                 */
+                static record_size_t computeHeaderSize(const corrected_intensity_metric::header_type&)
+                {
+                    return sizeof(record_size_t) + sizeof(::uint8_t);
                 }
             };
 #pragma pack()

--- a/src/interop/model/metrics/corrected_intensity_metric.cpp
+++ b/src/interop/model/metrics/corrected_intensity_metric.cpp
@@ -115,7 +115,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const corrected_intensity_metric::header_type&)
                 {
-                    return sizeof(record_size_t) + sizeof(::uint8_t);
+                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
                 }
             };
             /** Corrected Intensity Metric Record Layout Version 3
@@ -204,7 +204,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const corrected_intensity_metric::header_type&)
                 {
-                    return sizeof(record_size_t) + sizeof(::uint8_t);
+                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
                 }
             };
 #pragma pack()

--- a/src/interop/model/metrics/error_metric.cpp
+++ b/src/interop/model/metrics/error_metric.cpp
@@ -92,6 +92,14 @@ namespace illumina{ namespace interop{ namespace io {
                             sizeof(::uint32_t)*error_metric::MAX_MISMATCH   // m_mismatch_cluster_count
                     );
                 }
+                /** Compute header size
+                 *
+                 * @return header size
+                 */
+                static record_size_t computeHeaderSize(const error_metric::header_type&)
+                {
+                    return sizeof(record_size_t) + sizeof(::uint8_t);
+                }
             };
 
 

--- a/src/interop/model/metrics/error_metric.cpp
+++ b/src/interop/model/metrics/error_metric.cpp
@@ -98,7 +98,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const error_metric::header_type&)
                 {
-                    return sizeof(record_size_t) + sizeof(::uint8_t);
+                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
                 }
             };
 

--- a/src/interop/model/metrics/extraction_metric.cpp
+++ b/src/interop/model/metrics/extraction_metric.cpp
@@ -104,7 +104,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const extraction_metric::header_type&)
                 {
-                    return sizeof(record_size_t) + sizeof(::uint8_t);
+                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
                 }
             private:
                 static void convert_datetime(std::ostream&, const extraction_metric&)

--- a/src/interop/model/metrics/extraction_metric.cpp
+++ b/src/interop/model/metrics/extraction_metric.cpp
@@ -98,6 +98,14 @@ namespace illumina{ namespace interop{ namespace io {
                             sizeof(::uint64_t)                                  // m_dateTime
                     );
                 }
+                /** Compute header size
+                 *
+                 * @return header size
+                 */
+                static record_size_t computeHeaderSize(const extraction_metric::header_type&)
+                {
+                    return sizeof(record_size_t) + sizeof(::uint8_t);
+                }
             private:
                 static void convert_datetime(std::ostream&, const extraction_metric&)
                 {

--- a/src/interop/model/metrics/image_metric.cpp
+++ b/src/interop/model/metrics/image_metric.cpp
@@ -125,7 +125,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const image_metric::header_type&)
                 {
-                    return sizeof(record_size_t) + sizeof(::uint8_t);
+                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
                 }
             };
 
@@ -225,7 +225,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const image_metric::header_type&)
                 {
-                    return sizeof(::uint8_t) + sizeof(record_size_t) + sizeof(::uint8_t);
+                    return static_cast<record_size_t>(sizeof(::uint8_t) + sizeof(record_size_t) + sizeof(::uint8_t));
                 }
             };
 #pragma pack() // DO NOT MOVE

--- a/src/interop/model/metrics/image_metric.cpp
+++ b/src/interop/model/metrics/image_metric.cpp
@@ -119,6 +119,14 @@ namespace illumina{ namespace interop{ namespace io {
                             sizeof(metric_id_t)+sizeof(record_t)
                     );
                 }
+                /** Compute header size
+                 *
+                 * @return header size
+                 */
+                static record_size_t computeHeaderSize(const image_metric::header_type&)
+                {
+                    return sizeof(record_size_t) + sizeof(::uint8_t);
+                }
             };
 
             /** Image Metric Record Layout Version 2
@@ -210,6 +218,14 @@ namespace illumina{ namespace interop{ namespace io {
                 static std::streamsize map_stream_for_header(Stream& stream, Header& header)
                 {
                     return stream_map< ::uint8_t >(stream, header.m_channelCount);
+                }
+                /** Compute header size
+                 *
+                 * @return header size
+                 */
+                static record_size_t computeHeaderSize(const image_metric::header_type&)
+                {
+                    return sizeof(::uint8_t) + sizeof(record_size_t) + sizeof(::uint8_t);
                 }
             };
 #pragma pack() // DO NOT MOVE

--- a/src/interop/model/metrics/index_metric.cpp
+++ b/src/interop/model/metrics/index_metric.cpp
@@ -132,6 +132,14 @@ struct generic_layout<index_metric, 1> : public default_layout<1>
     {
         return record_size_t();
     }
+    /** Compute header size
+     *
+     * @return header size
+     */
+    static size_t computeHeaderSize(const index_metric::header_type&)
+    {
+        return sizeof(::uint8_t);
+    }
 };
 
 #pragma pack()

--- a/src/interop/model/metrics/q_metric.cpp
+++ b/src/interop/model/metrics/q_metric.cpp
@@ -89,7 +89,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const q_metric::header_type&)
                 {
-                    return sizeof(record_size_t) + sizeof(::uint8_t);
+                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
                 }
             };
             /** Q-score Metric Record Layout Version 5
@@ -251,12 +251,12 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const q_metric::header_type& header)
                 {
-                    if(header.binCount()==0) return sizeof(record_size_t) + sizeof(::uint8_t) + sizeof(::uint8_t);
-                    return sizeof(record_size_t) +
+                    if(header.binCount()==0) return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t) + sizeof(::uint8_t));
+                    return static_cast<record_size_t>(sizeof(record_size_t) +
                             sizeof(::uint8_t) + // record size
                             sizeof(::uint8_t) + // has bins
                             sizeof(::uint8_t) + // number of bins
-                            header.m_bin_count*3*sizeof(::uint8_t);
+                            header.m_bin_count*3*sizeof(::uint8_t));
                 }
             private:
                 template<size_t N>
@@ -429,12 +429,12 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const q_metric::header_type& header)
                 {
-                    if(header.binCount()==0) return sizeof(record_size_t) + sizeof(::uint8_t) + sizeof(::uint8_t);
-                    return sizeof(record_size_t) +
+                    if(header.binCount()==0) return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t) + sizeof(::uint8_t));
+                    return static_cast<record_size_t>(sizeof(record_size_t) +
                            sizeof(::uint8_t) + // version
                            sizeof(::uint8_t) + // has bins
                            sizeof(::uint8_t) + // number of bins
-                           header.m_bin_count*3*sizeof(::uint8_t);
+                           header.m_bin_count*3*sizeof(::uint8_t));
                 }
             private:
                 template<size_t N>

--- a/src/interop/model/metrics/q_metric.cpp
+++ b/src/interop/model/metrics/q_metric.cpp
@@ -83,6 +83,14 @@ namespace illumina{ namespace interop{ namespace io {
                 {
                     return static_cast<record_size_t>(sizeof(metric_id_t)+sizeof(::uint32_t)*q_metric::MAX_Q_BINS);
                 }
+                /** Compute header size
+                 *
+                 * @return header size
+                 */
+                static record_size_t computeHeaderSize(const q_metric::header_type&)
+                {
+                    return sizeof(record_size_t) + sizeof(::uint8_t);
+                }
             };
             /** Q-score Metric Record Layout Version 5
              *
@@ -235,6 +243,20 @@ namespace illumina{ namespace interop{ namespace io {
                     copy_value_read(header.m_qscoreBins, tmp);
 
                     return count;
+                }
+                /** Compute header size
+                 *
+                 * @param header q-metric header
+                 * @return header size
+                 */
+                static record_size_t computeHeaderSize(const q_metric::header_type& header)
+                {
+                    if(header.binCount()==0) return sizeof(record_size_t) + sizeof(::uint8_t) + sizeof(::uint8_t);
+                    return sizeof(record_size_t) +
+                            sizeof(::uint8_t) + // record size
+                            sizeof(::uint8_t) + // has bins
+                            sizeof(::uint8_t) + // number of bins
+                            header.m_bin_count*3*sizeof(::uint8_t);
                 }
             private:
                 template<size_t N>
@@ -399,6 +421,20 @@ namespace illumina{ namespace interop{ namespace io {
                     copy_value_read(header.m_qscoreBins, tmp);
 
                     return count;
+                }
+                /** Compute header size
+                 *
+                 * @param header q-metric header
+                 * @return header size
+                 */
+                static record_size_t computeHeaderSize(const q_metric::header_type& header)
+                {
+                    if(header.binCount()==0) return sizeof(record_size_t) + sizeof(::uint8_t) + sizeof(::uint8_t);
+                    return sizeof(record_size_t) +
+                           sizeof(::uint8_t) + // version
+                           sizeof(::uint8_t) + // has bins
+                           sizeof(::uint8_t) + // number of bins
+                           header.m_bin_count*3*sizeof(::uint8_t);
                 }
             private:
                 template<size_t N>

--- a/src/interop/model/metrics/tile_metric.cpp
+++ b/src/interop/model/metrics/tile_metric.cpp
@@ -207,6 +207,14 @@ namespace illumina{ namespace interop{
                 {
                     return static_cast< record_size_t >(sizeof(metric_id_t)+sizeof(record_t));
                 }
+                /** Compute header size
+                 *
+                 * @return header size
+                 */
+                static record_size_t computeHeaderSize(const tile_metric::header_type&)
+                {
+                    return sizeof(record_size_t) + sizeof(::uint8_t);
+                }
 
             private:
                 static tile_metric::read_metric_vector::iterator get_read(tile_metric& metric, tile_metric::read_metric_type::uint_t read)

--- a/src/interop/model/metrics/tile_metric.cpp
+++ b/src/interop/model/metrics/tile_metric.cpp
@@ -213,7 +213,7 @@ namespace illumina{ namespace interop{
                  */
                 static record_size_t computeHeaderSize(const tile_metric::header_type&)
                 {
-                    return sizeof(record_size_t) + sizeof(::uint8_t);
+                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
                 }
 
             private:

--- a/src/tests/csharp/metrics/ImageMetricsTest.cs
+++ b/src/tests/csharp/metrics/ImageMetricsTest.cs
@@ -34,6 +34,7 @@ namespace illumina.interop.csharp.unittest
 		/// </summary>
 		/// <param name="tmp">Hard coded binary data</param>
 		/// <param name="version">Version of the format</param>
+		/// <param name="channelCount">Number of channels</param>
 	    protected void SetupBuffers(int[] tmp, short version, ushort channelCount)
 	    {
 	        expected_binary_data = new byte[tmp.Length];

--- a/src/tests/csharp/metrics/QMetricsTest.cs
+++ b/src/tests/csharp/metrics/QMetricsTest.cs
@@ -35,6 +35,7 @@ namespace illumina.interop.csharp.unittest
 		/// </summary>
 		/// <param name="tmp">Hard coded binary data</param>
 		/// <param name="version">Version of the format</param>
+		/// <param name="header">Header for the file format</param>
 	    protected void SetupBuffers(int[] tmp, short version, q_score_header header)
 	    {
 	        expected_binary_data = new byte[tmp.Length];


### PR DESCRIPTION
Adds the ability to calculate the size of an InterOp file header