### PR TITLE
IPA-3867: Unclear error when empty file is given

### DIFF
--- a/interop/io/metric_stream.h
+++ b/interop/io/metric_stream.h
@@ -74,7 +74,12 @@ namespace illumina {
                 typedef typename factory_type::metric_format_map metric_format_map;
                 metric_format_map& format_map=factory_type::metric_formats();
 
+                if(!in.good())
+                    throw incomplete_file_exception("Empty file found");
+
                 const int version = in.get();
+                if(version == -1)
+                    throw incomplete_file_exception("Empty file found");
                 if (format_map.find(version) == format_map.end())
                     throw bad_format_exception("No format found to parse file with version: " +
                                                util::lexical_cast<std::string>(version) + " of " +

--- a/src/apps/interop2csv.cpp
+++ b/src/apps/interop2csv.cpp
@@ -211,13 +211,13 @@ int read_metrics_from_file(const std::string& filename, MetricSet& metrics)
     catch(const io::file_not_found_exception&){return 1;}
     catch(const io::bad_format_exception& ex)
     {
-        if(kPrintError) std::cerr << ex.what() << std::endl;
+        if(kPrintError) std::cerr << metrics.name() << " - " << ex.what() << std::endl;
         return BAD_FORMAT;
     }
     catch(const io::incomplete_file_exception&){ }
     catch(const std::exception& ex)
     {
-        if(kPrintError) std::cerr << ex.what() << std::endl;
+        if(kPrintError) std::cerr << metrics.name() << " - " << ex.what() << std::endl;
         return UNEXPECTED_EXCEPTION;
     }
     if(metrics.size()==0)


### PR DESCRIPTION
An empty InterOp file will produce the following error message:
"No format found to parse file with version: -1 of 1 "

This does not tell you which InterOp file failed, nor does it tell you what the problem was.

An empty InterOp file should be considered an incomplete file, which interop2csv will ignore.