### PR TITLE
IPA-4195: Remove legacy error metric fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         sources:
         - george-edison55-precise-backports
         - ubuntu-toolchain-r-test
-        - teward-swig3.0
+        - teward
         packages:
         - cmake
         - cmake-data
@@ -42,7 +42,7 @@ matrix:
         - george-edison55-precise-backports
         - ubuntu-toolchain-r-test
         - llvm-toolchain-precise-3.7
-        - teward-swig3.0
+        - teward
         packages:
         - cmake
         - cmake-data

--- a/cmake/Modules/FindNUnit.cmake
+++ b/cmake/Modules/FindNUnit.cmake
@@ -72,6 +72,13 @@ else()
 endif()
 
 if(NOT NUNIT_LIBRARY OR NOT NUNIT_COMMAND)
+    if(NUNIT_ROOT)
+        if(NOT NUNIT_LIBRARY)
+            message(WARNING "NUNIT library not found at root: ${NUNIT_ROOT}")
+        else()
+            message(WARNING "NUNIT command not found at root: ${NUNIT_ROOT} with library: ${NUNIT_LIBRARY}")
+        endif()
+    endif()
     include(ExternalProject)
     ExternalProject_Add(
             NUnit

--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -3,6 +3,10 @@
 
 ## Trunk
 
+Commit  | Description
+------- | -----------
+585eb43 | Remove legacy error metric fields
+
 ## v1.0.3
 
 Commit  | Description

--- a/interop/model/metrics/error_metric.h
+++ b/interop/model/metrics/error_metric.h
@@ -52,7 +52,6 @@ namespace illumina {
                     error_metric() :
                             metric_base::base_cycle_metric(0,0,0),
                             m_errorRate(0),
-                            m_totalReads(0),
                             m_mismatch_cluster_count(MAX_MISMATCH, 0)
                     {
                     }
@@ -69,7 +68,6 @@ namespace illumina {
                                  float error) :
                             metric_base::base_cycle_metric(lane,tile,cycle),
                             m_errorRate(error),
-                            m_totalReads(0),
                             m_mismatch_cluster_count(MAX_MISMATCH, 0)
                     {
                     }
@@ -92,22 +90,13 @@ namespace illumina {
                     {
                         return m_errorRate;
                     }
-                    /** Total number of reads
-                     *
-                     * @note Supported by all versions
-                     * @return total number of reads
-                     */
-                    uint_t totalReads()const
-                    {
-                        return m_totalReads;
-                    }
                     /** Number of clusters at given number of mismatches
                      *
                      * 0: no mismatches
                      * 1: 1 mismatch
                      * etc.
                      *
-                     * @note Unsupported on most platforms (TODO: MiSeq supported?)
+                     * @note Unsupported on most platforms, some older MiSeq and HiSeq support
                      * @param n index of read
                      * @return total number of errors
                      */
@@ -118,7 +107,7 @@ namespace illumina {
                     }
                     /** Size of mismatch array
                      *
-                     * @note Unsupported on most platforms (TODO: MiSeq supported?)
+                     * @note Unsupported on most platforms, some older MiSeq and HiSeq support
                      * @return total number of errors
                      */
                     uint_t mismatch_count()const
@@ -131,6 +120,7 @@ namespace illumina {
                      * 1: 1 mismatch
                      * etc.
                      *
+                     * @note Unsupported on most platforms, some older MiSeq and HiSeq support
                      * @return vector of mismatch cluster counts
                      */
                     const uint_array_t& mismatch_cluster_counts()const
@@ -148,7 +138,6 @@ namespace illumina {
 
                 private:
                     float m_errorRate;
-                    uint_t m_totalReads;
                     uint_array_t m_mismatch_cluster_count;
                     template<class MetricType, int Version>
                     friend struct io::generic_layout;

--- a/src/apps/interop2csv.cpp
+++ b/src/apps/interop2csv.cpp
@@ -354,12 +354,12 @@ int write_error_metrics(std::ostream& out, const std::string& filename)
     if(res != 0) return res;
 
     write_header(out, metrics);
-    out << "Lane,Tile,Cycle,Error,ReadCount,ErrorCount\n";
+    out << "Lane,Tile,Cycle,Error\n";
     for(error_metrics::metric_array_t::const_iterator beg = metrics.metrics().begin(), end = vec_end(metrics.metrics());beg != end;++beg)
     {
         const error_metric& metric = *beg;
         write_id(out, metric);
-        out << metric.errorRate() << "," << metric.totalReads() << "," << metric.mismatch_count() << "\n";
+        out << metric.errorRate() << "\n";
     }
 
     return res;

--- a/src/interop/model/metrics/error_metric.cpp
+++ b/src/interop/model/metrics/error_metric.cpp
@@ -8,7 +8,6 @@
  *  @version 1.0
  *  @copyright GNU Public License.
  */
-
 #include "interop/model/metrics/error_metric.h"
 #include "interop/io/format/metric_format_factory.h"
 
@@ -100,6 +99,7 @@ namespace illumina{ namespace interop{ namespace io {
                 {
                     return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
                 }
+
             };
 
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_custom_target(check)
 add_custom_target(performance)
-set_target_properties(check PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
+set_target_properties(check performance PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
 
 
 

--- a/src/tests/csharp/CMakeLists.txt
+++ b/src/tests/csharp/CMakeLists.txt
@@ -6,13 +6,12 @@
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 find_package(CSharp)
-find_package(SWIG)
-find_package(NUnit)
 
 if(NOT CSHARP_FOUND)
     return()
 endif()
 
+find_package(SWIG)
 if(NOT SWIG_FOUND)
     return()
 endif()
@@ -22,6 +21,7 @@ if(swig_major_ver LESS "3")
     return()
 endif()
 
+find_package(NUnit)
 if(NOT NUNIT_FOUND)
     message(WARNING "NUnit not found, C# unit testing will be disabled")
     message(WARNING "You may set the location of NUNIT with NUNIT_ROOT or the NUNIT_DIR environment variable")

--- a/tools/travis-linux-install.sh
+++ b/tools/travis-linux-install.sh
@@ -2,7 +2,7 @@
 
 lsb_release -a
 
-sudo apt-get update -qq
+#sudo apt-get update -qq
 sudo apt-get install -qq -y mono-complete
 sudo apt-get install -qq libgtest-dev
 


### PR DESCRIPTION
totalReads should never have been included with error metrics. This field was deprecated a while back and can be calculated on all platforms by multiplying the cluster count PF by the % aligned.

This addresses the bug report in: https://github.com/Illumina/interop/issues/30