### PR TITLE
IPA-4146: Refactor unit tests to support summary

### DIFF
--- a/src/tests/interop/CMakeLists.txt
+++ b/src/tests/interop/CMakeLists.txt
@@ -11,7 +11,18 @@ add_executable(interop_gtests
         metrics/image_metrics_test.cpp
         metrics/index_metrics_test.cpp
         metrics/q_metrics_test.cpp
-        metrics/tile_metrics_test.cpp)
+        metrics/tile_metrics_test.cpp
+        metrics/inc/corrected_intensity_metrics_test.h
+        metrics/inc/error_metrics_test.h
+        metrics/inc/metric_test.h
+        metrics/inc/stream_tests.hpp
+        metrics/inc/summary_fixture.h
+        metrics/inc/extraction_metrics_test.h
+        metrics/inc/image_metrics_test.h
+        metrics/inc/index_metrics_test.h
+        metrics/inc/q_metrics_test.h
+        metrics/inc/tile_metrics_test.h
+        metrics/base_metric_tests.cpp)
 
 target_link_libraries(interop_gtests ${INTEROP_LIB} ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 add_test(NAME interop_gtests WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testBin

--- a/src/tests/interop/metrics/base_metric_tests.cpp
+++ b/src/tests/interop/metrics/base_metric_tests.cpp
@@ -1,0 +1,28 @@
+/** Unit tests for base metric operations
+ *
+ *
+ *  @file
+ *  @date  3/24/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#include <gtest/gtest.h>
+#include "interop/io/layout/base_metric.h"
+
+#ifdef _MSC_VER
+#pragma warning(push)
+    #pragma warning(disable:4127) // MSVC warns about using constants in conditional statements, for template constants
+#endif
+
+using namespace illumina::interop::io::layout;
+
+
+TEST(base_metric_test, lane_from_id)
+{
+    base_metric::id_t id = base_metric::id(8, 1323);
+    EXPECT_EQ(base_metric::lane_from_id(id), 8u);
+
+
+    base_metric::id_t id2 = base_metric::id(1, 1);
+    EXPECT_EQ(base_metric::lane_from_id(id2), 1u);
+}

--- a/src/tests/interop/metrics/corrected_intensity_metrics_test.cpp
+++ b/src/tests/interop/metrics/corrected_intensity_metrics_test.cpp
@@ -2,208 +2,56 @@
  *
  *
  *  @file
- *
  *  @date 8/7/2015
  *  @version 1.0
  *  @copyright GNU Public License.
  */
 
+#ifdef _MSC_VER
+    #pragma warning(push)
+    #pragma warning(disable:4127) // MSVC warns about using constants in conditional statements, for template constants
+#endif
 
 #include <fstream>
-#include <gtest/gtest.h>
-#include "interop/model/metric_sets/corrected_intensity_metric_set.h"
-#include "src/tests/interop/metrics/metric_test_utils.h"
+#include "inc/corrected_intensity_metrics_test.h"
 using namespace illumina::interop::model::metrics;
 using namespace illumina::interop;
 using namespace illumina::interop::io;
-
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4127) // MSVC warns about using constants in conditional statements, for template constants
-#endif
-
-
-namespace illumina{ namespace interop { namespace unittest {
-/** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
- * to the values displayed in SAV.
- *
- * Regression Test: 1947950_117213Bin2R0I
- *
- * @note Version 2
- */
-struct corrected_intensity_hardcoded_fixture_v2 : util::fixture_helper<corrected_intensity_metrics, 2>
-{
-    /** Setup fixture */
-    corrected_intensity_hardcoded_fixture_v2()
-    {
-        typedef metric_type::uint_t uint_t;
-        typedef metric_type::ushort_t ushort_t;
-        ushort_t correctedIntAll1[] = {1213, 966, 960, 1095};
-        ushort_t correctedIntCalled1[] = {4070, 4074, 4029, 3972};
-        uint_t calledCounts1[] = {0, 698433, 548189, 548712, 646638};
-        expected_metrics.push_back(
-                metric_type(1, 1104, 25, 1063, 11.9458876f, to_vector(correctedIntCalled1), to_vector(correctedIntAll1),
-                            to_vector(calledCounts1)));
-        ushort_t correctedIntAll2[] = {1558, 1151, 1158, 1293};
-        uint_t calledCounts2[] = {10938, 733661, 537957, 543912, 615504};
-        ushort_t correctedIntCalled2[] = {5013, 4983, 4915, 4932};
-        expected_metrics.push_back(
-                metric_type(1, 1104, 1, 1295, 13.3051805f, to_vector(correctedIntCalled2), to_vector(correctedIntAll2),
-                            to_vector(calledCounts2)));
-        ushort_t correctedIntAll3[] = {1171, 932, 912, 1069};
-        uint_t calledCounts3[] = {0, 706987, 556441, 556067, 653959};
-        ushort_t correctedIntCalled3[] = {3931, 3931, 3923, 3878};
-        expected_metrics.push_back(
-                metric_type(1, 1105, 25, 1025, 11.7396259f, to_vector(correctedIntCalled3), to_vector(correctedIntAll3),
-                            to_vector(calledCounts3)));
-
-        int tmp[] = {2, 48, 1, 0, 80, 4, 25, 0, 39, 4, 189, 4, 198, 3, 192, 3, 71, 4, 230, 15, 234, 15, 189, 15, 132,
-                     15, 0, 0, 0, 0, 65, 168, 10, 0, 93, 93, 8, 0, 104, 95, 8, 0, 238, 221, 9, 0, 91, 34, 63, 65, 1, 0,
-                     80, 4, 1, 0, 15, 5, 22, 6, 127, 4, 134, 4, 13, 5, 149, 19, 119, 19, 51, 19, 68, 19, 186, 42, 0, 0,
-                     221, 49, 11, 0, 101, 53, 8, 0, 168, 76, 8, 0, 80, 100, 9, 0, 5, 226, 84, 65, 1, 0, 81, 4, 25, 0, 1,
-                     4, 147, 4, 164, 3, 144, 3, 45, 4, 91, 15, 91, 15, 83, 15, 38, 15, 0, 0, 0, 0, 171, 201, 10, 0, 153,
-                     125, 8, 0, 35, 124, 8, 0, 135, 250, 9, 0, 130, 213, 59, 65
-        };
-        setup_hardcoded_binary(tmp, header_type());
-    }
-};
-
-/** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
- * to the values displayed in SAV.
- *
- * @note Version 3
- */
-struct corrected_intensity_hardcoded_fixture_v3 : util::fixture_helper<corrected_intensity_metrics, 3>
-{
-    /** Setup fixture */
-    corrected_intensity_hardcoded_fixture_v3()
-    {
-        typedef metric_type::uint_t uint_t;
-        typedef metric_type::ushort_t ushort_t;
-        uint_t calledCounts1[] = {52, 1049523, 654071, 500476, 982989};
-        ushort_t correctedIntCalled1[] = {245, 252, 61, 235};
-        //expected_metrics.push_back(metric_type(7, 1114, 1, to_vector(correctedIntCalled1), to_vector(calledCounts1)));
-        expected_metrics.push_back(metric_type(7, 1114, 1, (correctedIntCalled1), (calledCounts1)));
-        uint_t calledCounts2[] = {0, 1063708, 582243, 588028, 953132};
-        ushort_t correctedIntCalled2[] = {232, 257, 68, 228};
-        //expected_metrics.push_back(metric_type(7, 1114, 2, to_vector(correctedIntCalled2), to_vector(calledCounts2)));
-        expected_metrics.push_back(metric_type(7, 1114, 2, (correctedIntCalled2), (calledCounts2)));
-        uint_t calledCounts3[] = {0, 1022928, 617523, 594836, 951825};
-        ushort_t correctedIntCalled3[] = {227, 268, 68, 229};
-        expected_metrics.push_back(metric_type(7, 1114, 3, (correctedIntCalled3), (calledCounts3)));
-        //expected_metrics.push_back(metric_type(7, 1114, 3, to_vector(correctedIntCalled3), to_vector(calledCounts3)));
-
-        int tmp[] = {3, 34, 7, 0, 90, 4, 1, 0, -11, 0, -4, 0, 61, 0, -21, 0, 52, 0, 0, 0, -77, 3, 16, 0, -9, -6, 9, 0,
-                     -4, -94, 7, 0, -51, -1, 14, 0, 7, 0, 90, 4, 2, 0, -24, 0, 1, 1, 68, 0, -28, 0, 0, 0, 0, 0, 28, 59,
-                     16, 0, 99, -30, 8, 0, -4, -8, 8, 0, 44, -117, 14, 0, 7, 0, 90, 4, 3, 0, -29, 0, 12, 1, 68, 0, -27,
-                     0, 0, 0, 0, 0, -48, -101, 15, 0, 51, 108, 9, 0, -108, 19, 9, 0, 17, -122, 14, 0
-        };
-        setup_hardcoded_binary(tmp, header_type());
-    }
-};
-
-/** This test writes three records of an InterOp files, then reads them back in and compares
- * each value to ensure they did not change.
- *
- * @note Version 2
- */
-struct corrected_intensity_write_read_fixture_v2 : util::fixture_helper<corrected_intensity_metrics, 2>
-{
-    /** Setup fixture */
-    corrected_intensity_write_read_fixture_v2()
-    {
-        typedef metric_type::uint_t uint_t;
-        typedef metric_type::ushort_t ushort_t;
-        ushort_t correctedIntAll1[] = {1213, 966, 960, 1095};
-        ushort_t correctedIntCalled1[] = {4070, 4074, 4029, 3972};
-        uint_t calledCounts1[] = {0, 698433, 548189, 548712, 646638};
-        expected_metrics.push_back(
-                metric_type(1, 1104, 25, 1063, 11.9458876f, to_vector(correctedIntCalled1), to_vector(correctedIntAll1),
-                            to_vector(calledCounts1)));
-        ushort_t correctedIntAll2[] = {1558, 1151, 1158, 1293};
-        uint_t calledCounts2[] = {10938, 733661, 537957, 543912, 615504};
-        ushort_t correctedIntCalled2[] = {5013, 4983, 4915, 4932};
-        expected_metrics.push_back(
-                metric_type(1, 1104, 1, 1295, 13.3051805f, to_vector(correctedIntCalled2), to_vector(correctedIntAll2),
-                            to_vector(calledCounts2)));
-        ushort_t correctedIntAll3[] = {1171, 932, 912, 1069};
-        uint_t calledCounts3[] = {0, 706987, 556441, 556067, 653959};
-        ushort_t correctedIntCalled3[] = {3931, 3931, 3923, 3878};
-        expected_metrics.push_back(
-                metric_type(1, 1105, 25, 1025, 11.7396259f, to_vector(correctedIntCalled3), to_vector(correctedIntAll3),
-                            to_vector(calledCounts3)));
-        setup_write_read();
-    }
-};
-
-
-/** This test writes three records of an InterOp files, then reads them back in and compares
- * each value to ensure they did not change.
- *
- * @note Version 3
- */
-struct corrected_intensity_write_read_fixture_v3 : util::fixture_helper<corrected_intensity_metrics, 3>
-{
-    /** Setup fixture */
-    corrected_intensity_write_read_fixture_v3()
-    {
-        typedef metric_type::uint_t uint_t;
-        typedef metric_type::ushort_t ushort_t;
-        uint_t calledCounts1[] = {52, 1049523, 654071, 500476, 982989};
-        ushort_t correctedIntCalled1[] = {245, 252, 61, 235};
-        expected_metrics.push_back(metric_type(7, 1114, 1, to_vector(correctedIntCalled1), to_vector(calledCounts1)));
-        uint_t calledCounts2[] = {0, 1063708, 582243, 588028, 953132};
-        ushort_t correctedIntCalled2[] = {232, 257, 68, 228};
-        expected_metrics.push_back(metric_type(7, 1114, 2, to_vector(correctedIntCalled2), to_vector(calledCounts2)));
-        uint_t calledCounts3[] = {0, 1022928, 617523, 594836, 951825};
-        ushort_t correctedIntCalled3[] = {227, 268, 68, 229};
-        expected_metrics.push_back(metric_type(7, 1114, 3, to_vector(correctedIntCalled3), to_vector(calledCounts3)));
-        setup_write_read();
-    }
-};
-
-/** Interface between fixtures and Google Test */
-template<typename TestSetup>
-struct corrected_intensity_metrics_test : public ::testing::Test, public TestSetup { };
-
-}}}
 using namespace illumina::interop::unittest;
 
 
 typedef ::testing::Types<
-corrected_intensity_hardcoded_fixture_v2,
-corrected_intensity_hardcoded_fixture_v3
-,corrected_intensity_write_read_fixture_v2,
-corrected_intensity_write_read_fixture_v3
+        hardcoded_fixture<corrected_intensity_v2>,
+        hardcoded_fixture<corrected_intensity_v3>,
+        write_read_fixture<corrected_intensity_v2>,
+        write_read_fixture<corrected_intensity_v3>
 > Formats;
 TYPED_TEST_CASE(corrected_intensity_metrics_test, Formats);
 
-
-/**
- * @class illumina::interop::model::metrics::corrected_intensity_metric
- * @test Confirm version 2 of the metric can be written to and read from a stream
- * @test Confirm version 3 of the metric can be written to and read from a stream
- * @test Confirm version 2 of the metric matches known binary file
- * @test Confirm version 3 of the metric matches known binary file
+/** Compare two corrected intensity metric sets
+ *
+ * @param actual metric set read from stream
+ * @param expected metric set setup from known data
  */
-TYPED_TEST(corrected_intensity_metrics_test, test_read_write)
+template<class T>
+void compare_metrics(const T& actual, const T& expected)
 {
-    EXPECT_EQ(TypeParam::actual_metric_set.version(), TypeParam::VERSION);
-    EXPECT_EQ(TypeParam::actual_metrics.size(), TypeParam::expected_metrics.size());
-    EXPECT_EQ(TypeParam::actual_metric_set.max_cycle(), TypeParam::expected_metric_set.max_cycle());
+    EXPECT_EQ(actual.version(), expected.version());
+    EXPECT_EQ(actual.size(), expected.size());
+    EXPECT_EQ(actual.max_cycle(), expected.max_cycle());
 
-    for(typename TypeParam::const_iterator itExpected=TypeParam::expected_metrics.begin(), itActual = TypeParam::actual_metrics.begin();
-        itExpected != TypeParam::expected_metrics.end() && itActual != TypeParam::actual_metrics.end();
+    for(typename T::const_iterator itExpected=expected.begin(), itActual = actual.begin();
+        itExpected != expected.end() && itActual != actual.end();
         itExpected++,itActual++)
     {
         EXPECT_EQ(itExpected->lane(), itActual->lane());
         EXPECT_EQ(itExpected->tile(), itActual->tile());
         EXPECT_EQ(itExpected->cycle(), itActual->cycle());
-        if(TypeParam::VERSION < 3)
+        if(expected.version() < 3)
         {
             EXPECT_EQ(itExpected->averageCycleIntensity(), itActual->averageCycleIntensity());
         }
-        if(TypeParam::VERSION == 2)
+        if(expected.version() == 2)
         {
             if (!std::isnan(itExpected->signalToNoise()) || !std::isnan(itActual->signalToNoise()))
                 EXPECT_NEAR(itExpected->signalToNoise(), itActual->signalToNoise(), 1e-7f);
@@ -213,11 +61,24 @@ TYPED_TEST(corrected_intensity_metrics_test, test_read_write)
         for(size_t i=0;i<constants::NUM_OF_BASES;i++)
         {
             EXPECT_EQ(itExpected->correctedIntCalled(i), itActual->correctedIntCalled(i));
-            if(TypeParam::VERSION < 3) {
+            if(expected.version() < 3)
+            {
                 EXPECT_EQ(itExpected->correctedIntAll(i), itActual->correctedIntAll(i));
             }
         }
     }
+}
+
+/**
+ * @class illumina::interop::model::metrics::corrected_intensity_metric
+ * @test Confirm version 2 of the metric matches known binary file
+ * @test Confirm version 3 of the metric matches known binary file
+ * @test Confirm version 2 of the metric can be written to and read from a stream
+ * @test Confirm version 3 of the metric can be written to and read from a stream
+ */
+TYPED_TEST(corrected_intensity_metrics_test, test_metric_io_fidelity)
+{
+    compare_metrics(TypeParam::actual_metric_set, TypeParam::expected_metric_set);
 }
 
 #define FIXTURE corrected_intensity_metrics_test
@@ -231,7 +92,7 @@ TYPED_TEST(corrected_intensity_metrics_test, test_read_write)
  * @test Confirm file_not_found_exception is thrown when a file is not found
  * @test Confirm reading from good data does not throw an exception
  */
-#include "src/tests/interop/metrics/stream_exception_tests.hpp"
+#include "inc/stream_tests.hpp"
 
 
 

--- a/src/tests/interop/metrics/extraction_metrics_test.cpp
+++ b/src/tests/interop/metrics/extraction_metrics_test.cpp
@@ -2,7 +2,6 @@
  *
  *
  *  @file
- *
  *  @date 8/24/2015
  *  @version 1.0
  *  @copyright GNU Public License.
@@ -11,86 +10,16 @@
 #include <limits>
 #include <fstream>
 #include <gtest/gtest.h>
-#include "interop/model/metric_sets/extraction_metric_set.h"
-#include "src/tests/interop/metrics/metric_test_utils.h"
+#include "inc/extraction_metrics_test.h"
 using namespace illumina::interop::model::metrics;
 using namespace illumina::interop::io;
-
-
-namespace illumina{ namespace interop { namespace unittest {
-/** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
- * to the values displayed in SAV.
- *
- * @note Version 2
- */
-struct extraction_metrics_hardcoded_fixture_v2 : util::fixture_helper<extraction_metrics, 2>
-{
-    enum{
-        /** Do not check the expected binary data */
-        disable_binary_data=true
-    };
-    /** Setup fixture */
-    extraction_metrics_hardcoded_fixture_v2()
-    {
-        typedef extraction_metric::ushort_t ushort_t;
-        float focus1[] = {2.24664021f, 2.1896739f, 0, 0};
-        ushort_t p90_1[]  = {302, 273, 0, 0};
-        expected_metrics.push_back(metric_type(7, 1114, 1, interop::util::csharp_date_time(9859129975844165472ul), to_vector(p90_1), to_vector(focus1)));
-        float focus2[] = {2.23177338f, 2.20616174f, 0, 0};
-        ushort_t p90_2[]  = {312, 273, 0, 0};
-        expected_metrics.push_back(metric_type(7, 1214, 1, interop::util::csharp_date_time(9859129975872781680ul), to_vector(p90_2), to_vector(focus2)));
-        float focus3[] = {2.10524225f, 2.14023066f, 0, 0};
-        ushort_t p90_3[]  = {349, 302, 0, 0};
-        expected_metrics.push_back(metric_type(7, 2114, 1, interop::util::csharp_date_time(9859129975901427921ul), to_vector(p90_3), to_vector(focus3)));
-        int tmp[] = {2,38,7,0,90,4,1,0,-12,-56,15,64,-98,35,12,64,0,0,0,0,0,0,0,0,46,1,17,1,0,0,0,0,96,-41,-104,36,122,-86,-46,-120
-                ,7,0,-66,4,1,0,96,-43,14,64,-63,49,13,64,0,0,0,0,0,0,0,0,56,1,17,1,0,0,0,0,112,125,77,38,122,-86,-46,-120
-                ,7,0,66,8,1,0,74,-68,6,64,-118,-7,8,64,0,0,0,0,0,0,0,0,93,1,46,1,0,0,0,0,-47,-104,2,40,122,-86,-46,-120
-        };
-        setup_hardcoded_binary(tmp, header_type());
-
-    }
-};
-
-
-/** This test writes three records of an InterOp files, then reads them back in and compares
- * each value to ensure they did not change.
- *
- * @note Version 2
- */
-struct extraction_metrics_write_read_fixture_v2 : util::fixture_helper<extraction_metrics, 2>
-{
-    enum{
-        /** Do not check the expected binary data */
-        disable_binary_data=true
-    };
-    /** Setup fixture */
-    extraction_metrics_write_read_fixture_v2()
-    {
-        typedef extraction_metric::ushort_t ushort_t;
-        float focus1[] = {2.24664021f, 2.1896739f, 0, 0};
-        ushort_t p90_1[]  = {302, 273, 0, 0};
-        expected_metrics.push_back(metric_type(7, 1114, 1, interop::util::csharp_date_time(9859129975844165472ul), to_vector(p90_1), to_vector(focus1)));
-        float focus2[] = {2.23177338f, 2.20616174f, 0, 0};
-        ushort_t p90_2[]  = {312, 273, 0, 0};
-        expected_metrics.push_back(metric_type(7, 1214, 1, interop::util::csharp_date_time(9859129975872781680ul), to_vector(p90_2), to_vector(focus2)));
-        float focus3[] = {2.10524225f, 2.14023066f, 0, 0};
-        ushort_t p90_3[]  = {349, 302, 0, 0};
-        expected_metrics.push_back(metric_type(7, 2114, 1, interop::util::csharp_date_time(9859129975901427921ul), to_vector(p90_3), to_vector(focus3)));
-        setup_write_read();
-
-    }
-};
-
-/** Interface between fixtures and Google Test */
-template<typename TestSetup>
-struct extraction_metrics_test : public ::testing::Test, public TestSetup { };
-}}}
+using namespace illumina::interop;
 using namespace illumina::interop::unittest;
 
 
 typedef ::testing::Types<
-extraction_metrics_hardcoded_fixture_v2,
-extraction_metrics_write_read_fixture_v2
+        hardcoded_fixture<extraction_v2>,
+        write_read_fixture<extraction_v2>
 > Formats;
 TYPED_TEST_CASE(extraction_metrics_test, Formats);
 
@@ -103,12 +32,12 @@ TYPED_TEST_CASE(extraction_metrics_test, Formats);
 TYPED_TEST(extraction_metrics_test, test_read_write)
 {
     EXPECT_EQ(TypeParam::actual_metric_set.version(), TypeParam::VERSION);
-    EXPECT_EQ(TypeParam::actual_metrics.size(), TypeParam::expected_metrics.size());
+    EXPECT_EQ(TypeParam::actual_metric_set.size(), TypeParam::expected_metric_set.size());
     EXPECT_EQ(TypeParam::actual_metric_set.max_cycle(), TypeParam::expected_metric_set.max_cycle());
 
 
-    for(typename TypeParam::const_iterator itExpected=TypeParam::expected_metrics.begin(), itActual = TypeParam::actual_metrics.begin();
-        itExpected != TypeParam::expected_metrics.end() && itActual != TypeParam::actual_metrics.end();
+    for(typename TypeParam::const_iterator itExpected=TypeParam::expected_metric_set.begin(), itActual = TypeParam::actual_metric_set.begin();
+        itExpected != TypeParam::expected_metric_set.end() && itActual != TypeParam::actual_metric_set.end();
         itExpected++,itActual++)
     {
         EXPECT_EQ(itExpected->lane(), itActual->lane());
@@ -128,6 +57,7 @@ TYPED_TEST(extraction_metrics_test, test_read_write)
         }
     }
 }
+
 #define FIXTURE extraction_metrics_test
 /**
  * @class illumina::interop::model::metrics::extraction_metric
@@ -139,4 +69,4 @@ TYPED_TEST(extraction_metrics_test, test_read_write)
  * @test Confirm file_not_found_exception is thrown when a file is not found
  * @test Confirm reading from good data does not throw an exception
  */
-#include "src/tests/interop/metrics/stream_exception_tests.hpp"
+#include "inc/stream_tests.hpp"

--- a/src/tests/interop/metrics/image_metrics_test.cpp
+++ b/src/tests/interop/metrics/image_metrics_test.cpp
@@ -2,7 +2,6 @@
  *
  *
  *  @file
- *
  *  @date 8/24/2015
  *  @version 1.0
  *  @copyright GNU Public License.
@@ -11,155 +10,17 @@
 #include <limits>
 #include <fstream>
 #include <gtest/gtest.h>
-#include "interop/model/metric_sets/image_metric_set.h"
-#include "src/tests/interop/metrics/metric_test_utils.h"
+#include "inc/image_metrics_test.h"
 using namespace illumina::interop::model::metrics;
 using namespace illumina::interop::io;
-
-
-
-namespace illumina{ namespace interop { namespace unittest {
-/** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
- * to the values displayed in SAV.
- *
- * Regression Test: 1947950_117213Bin2R0I
- *
- * @note Version 1
- */
-struct image_metrics_hardcoded_fixture_v1 : util::fixture_helper<image_metrics, 1>
-{
-    enum{
-        /** Do not check the expected binary data */
-                disable_binary_data=true
-    };
-    /** Setup fixture */
-    image_metrics_hardcoded_fixture_v1()
-    {
-        typedef image_metric::ushort_t ushort_t;
-        const ushort_t channel_count = image_metric::MAX_CHANNELS;
-        ushort_t min_contrast1[]  = {896, 1725,738,812};
-        ushort_t min_contrast2[]  = {908, 1770,739,806};
-        ushort_t min_contrast3[]  = {923, 1829,734,802};
-
-        ushort_t max_contrast1[]  = {4840, 8144,3308,4974};
-        ushort_t max_contrast2[]  = {4829, 8159,3302,4985};
-        ushort_t max_contrast3[]  = {4829, 8236,3304,4947};
-        expected_metrics.push_back(metric_type(1, 1101, 1, channel_count, to_vector(min_contrast1), to_vector(max_contrast1)));
-        expected_metrics.push_back(metric_type(1, 1102, 1, channel_count, to_vector(min_contrast2), to_vector(max_contrast2)));
-        expected_metrics.push_back(metric_type(1, 1103, 1, channel_count, to_vector(min_contrast3), to_vector(max_contrast3)));
-        int tmp[] = {1,12,
-                     1,0,77,4,1,0,0,0,128,3,232,18,
-                     1,0,77,4,1,0,1,0,189,6,208,31,
-                     1,0,77,4,1,0,2,0,226,2,236,12,
-                     1,0,77,4,1,0,3,0,44,3,110,19,
-                     1,0,78,4,1,0,0,0,140,3,221,18,
-                     1,0,78,4,1,0,1,0,234,6,223,31,
-                     1,0,78,4,1,0,2,0,227,2,230,12,
-                     1,0,78,4,1,0,3,0,38,3,121,19,
-                     1,0,79,4,1,0,0,0,155,3,221,18,
-                     1,0,79,4,1,0,1,0,37,7,44,32,
-                     1,0,79,4,1,0,2,0,222,2,232,12,
-                     1,0,79,4,1,0,3,0,34,3,83,19
-        };
-        setup_hardcoded_binary(tmp, header_type(metric_type::MAX_CHANNELS));
-    }
-};
-
-/** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
- * to the values displayed in SAV.
- *
- * @note Version 2
- */
-struct image_metrics_hardcoded_fixture_v2 : util::fixture_helper<image_metrics, 2>
-{
-    /** Setup fixture */
-    image_metrics_hardcoded_fixture_v2()
-    {
-        typedef image_metric::ushort_t ushort_t;
-        const ushort_t channel_count = 2;
-        ushort_t min_contrast1[]  = {231, 207};
-        ushort_t min_contrast2[]  = {229, 205};
-        ushort_t min_contrast3[]  = {231, 222};
-
-        ushort_t max_contrast1[]  = {462, 387};
-        ushort_t max_contrast2[]  = {457, 387};
-        ushort_t max_contrast3[]  = {473, 416};
-        expected_metrics.push_back(metric_type(7, 1114, 1, channel_count, to_vector(min_contrast1), to_vector(max_contrast1)));
-        expected_metrics.push_back(metric_type(7, 1214, 1, channel_count, to_vector(min_contrast2), to_vector(max_contrast2)));
-        expected_metrics.push_back(metric_type(7, 2114, 1, channel_count, to_vector(min_contrast3), to_vector(max_contrast3)));
-        int tmp[] = {2,14,2
-                ,7,0,90,4,1,0,-25,0,-49,0,-50,1,-125,1
-                ,7,0,-66,4,1,0,-27,0,-51,0,-55,1,-125,1
-                ,7,0,66,8,1,0,-25,0,-34,0,-39,1,-96,1
-        };
-        setup_hardcoded_binary(tmp, header_type(channel_count));
-    }
-};
-/** Defines buffers shared by many different tests
-*/
-struct image_metrics_write_read_fixture_v1 : util::fixture_helper<image_metrics, 1>
-{
-    enum{
-        /** Do not check the expected binary data */
-                disable_binary_data=true
-    };
-    /** Setup fixture */
-    image_metrics_write_read_fixture_v1()
-    {
-        typedef image_metric::ushort_t ushort_t;
-        const ushort_t channel_count = image_metric::MAX_CHANNELS;
-        ushort_t min_contrast1[]  = {231, 207,0,0};
-        ushort_t min_contrast2[]  = {229, 205,0,0};
-        ushort_t min_contrast3[]  = {231, 222,0,0};
-
-        ushort_t max_contrast1[]  = {462, 387,0,0};
-        ushort_t max_contrast2[]  = {457, 387,0,0};
-        ushort_t max_contrast3[]  = {473, 416,0,0};
-        expected_metrics.push_back(metric_type(7, 1114, 1, channel_count, to_vector(min_contrast1), to_vector(max_contrast1)));
-        expected_metrics.push_back(metric_type(7, 1214, 1, channel_count, to_vector(min_contrast2), to_vector(max_contrast2)));
-        expected_metrics.push_back(metric_type(7, 2114, 1, channel_count, to_vector(min_contrast3), to_vector(max_contrast3)));
-        setup_write_read(header_type(channel_count));
-    }
-};
-
-/** This test writes three records of an InterOp files, then reads them back in and compares
- * each value to ensure they did not change.
- *
- * @note Version 2
- */
-struct image_metrics_write_read_fixture_v2 : util::fixture_helper<image_metrics, 2>
-{
-    /** Setup fixture */
-    image_metrics_write_read_fixture_v2()
-    {
-        typedef image_metric::ushort_t ushort_t;
-        const ushort_t channel_count = 2;
-        ushort_t min_contrast1[]  = {231, 207};
-        ushort_t min_contrast2[]  = {229, 205};
-        ushort_t min_contrast3[]  = {231, 222};
-
-        ushort_t max_contrast1[]  = {462, 387};
-        ushort_t max_contrast2[]  = {457, 387};
-        ushort_t max_contrast3[]  = {473, 416};
-        expected_metrics.push_back(metric_type(7, 1114, 1, channel_count, to_vector(min_contrast1), to_vector(max_contrast1)));
-        expected_metrics.push_back(metric_type(7, 1214, 1, channel_count, to_vector(min_contrast2), to_vector(max_contrast2)));
-        expected_metrics.push_back(metric_type(7, 2114, 1, channel_count, to_vector(min_contrast3), to_vector(max_contrast3)));
-        setup_write_read(header_type(channel_count));
-    }
-};
-
-/** Interface between fixtures and Google Test */
-template<typename TestSetup>
-struct image_metrics_test : public ::testing::Test, public TestSetup { };
-}}}
 using namespace illumina::interop::unittest;
 
 
 typedef ::testing::Types<
-image_metrics_hardcoded_fixture_v1,
-image_metrics_hardcoded_fixture_v2,
-image_metrics_write_read_fixture_v1
-,image_metrics_write_read_fixture_v2
+        hardcoded_fixture<image_v1>,
+        write_read_fixture<image_v1>,
+        hardcoded_fixture<image_v2>,
+        write_read_fixture<image_v2>
 > Formats;
 TYPED_TEST_CASE(image_metrics_test, Formats);
 
@@ -174,12 +35,12 @@ TYPED_TEST_CASE(image_metrics_test, Formats);
 TYPED_TEST(image_metrics_test, test_read_write)
 {
     EXPECT_EQ(TypeParam::actual_metric_set.version(), TypeParam::VERSION);
-    EXPECT_EQ(TypeParam::actual_metrics.size(), TypeParam::expected_metrics.size());
+    EXPECT_EQ(TypeParam::actual_metric_set.size(), TypeParam::expected_metric_set.size());
     EXPECT_EQ(TypeParam::actual_metric_set.channelCount(), TypeParam::expected_metric_set.channelCount());
     EXPECT_EQ(TypeParam::actual_metric_set.max_cycle(), TypeParam::expected_metric_set.max_cycle());
 
-    for(typename TypeParam::const_iterator itExpected=TypeParam::expected_metrics.begin(), itActual = TypeParam::actual_metrics.begin();
-        itExpected != TypeParam::expected_metrics.end() && itActual != TypeParam::actual_metrics.end();
+    for(typename TypeParam::const_iterator itExpected=TypeParam::expected_metric_set.begin(), itActual = TypeParam::actual_metric_set.begin();
+        itExpected != TypeParam::expected_metric_set.end() && itActual != TypeParam::actual_metric_set.end();
         itExpected++,itActual++)
     {
         EXPECT_EQ(itExpected->lane(), itActual->lane());
@@ -204,6 +65,6 @@ TYPED_TEST(image_metrics_test, test_read_write)
  * @test Confirm file_not_found_exception is thrown when a file is not found
  * @test Confirm reading from good data does not throw an exception
  */
-#include "src/tests/interop/metrics/stream_exception_tests.hpp"
+#include "inc/stream_tests.hpp"
 
 

--- a/src/tests/interop/metrics/inc/corrected_intensity_metrics_test.h
+++ b/src/tests/interop/metrics/inc/corrected_intensity_metrics_test.h
@@ -1,0 +1,135 @@
+/** Unit tests for the corrected intensity metrics
+ *
+ *
+ *  @file
+ *  @date 3/10/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#pragma once
+#include <gtest/gtest.h>
+#include "metric_test.h"
+#include "interop/model/metrics/corrected_intensity_metric.h"
+
+
+namespace illumina{ namespace interop { namespace unittest {
+
+    /** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
+     * to the values displayed in SAV.
+     *
+     * Regression Test: 1947950_117213Bin2R0I
+     *
+     * @note Version 2
+     */
+    struct corrected_intensity_v2 : metric_test<model::metrics::corrected_intensity_metric, 2>
+    {
+        /** Build the expected metric set
+         *
+         * @return vector of metrics
+         */
+        static std::vector<metric_t> metrics()
+        {
+            typedef metric_t::uint_t uint_t;
+            typedef metric_t::ushort_t ushort_t;
+            std::vector<metric_t> metrics;
+            ushort_t correctedIntAll1[] = {1213, 966, 960, 1095};
+            ushort_t correctedIntCalled1[] = {4070, 4074, 4029, 3972};
+            uint_t calledCounts1[] = {0, 698433, 548189, 548712, 646638};
+            metrics.push_back(
+                    metric_t(1, 1104, 25, 1063, 11.9458876f, to_vector(correctedIntCalled1), to_vector(correctedIntAll1),
+                             to_vector(calledCounts1)));
+            ushort_t correctedIntAll2[] = {1558, 1151, 1158, 1293};
+            uint_t calledCounts2[] = {10938, 733661, 537957, 543912, 615504};
+            ushort_t correctedIntCalled2[] = {5013, 4983, 4915, 4932};
+            metrics.push_back(
+                    metric_t(1, 1104, 1, 1295, 13.3051805f, to_vector(correctedIntCalled2), to_vector(correctedIntAll2),
+                             to_vector(calledCounts2)));
+            ushort_t correctedIntAll3[] = {1171, 932, 912, 1069};
+            uint_t calledCounts3[] = {0, 706987, 556441, 556067, 653959};
+            ushort_t correctedIntCalled3[] = {3931, 3931, 3923, 3878};
+            metrics.push_back(
+                    metric_t(1, 1105, 25, 1025, 11.7396259f, to_vector(correctedIntCalled3), to_vector(correctedIntAll3),
+                             to_vector(calledCounts3)));
+            return metrics;
+        }
+        /** Get the expected metric set header
+         *
+         * @return expected metric set header
+         */
+        static header_t header()
+        {
+            return header_t();
+        }
+        /** Get the expected binary data
+         *
+         * @return binary data string
+         */
+        static std::string binary_data()
+        {
+            int tmp[] = {2, 48, 1, 0, 80, 4, 25, 0, 39, 4, 189, 4, 198, 3, 192, 3, 71, 4, 230, 15, 234, 15, 189, 15, 132,
+                      15, 0, 0, 0, 0, 65, 168, 10, 0, 93, 93, 8, 0, 104, 95, 8, 0, 238, 221, 9, 0, 91, 34, 63, 65, 1, 0,
+                      80, 4, 1, 0, 15, 5, 22, 6, 127, 4, 134, 4, 13, 5, 149, 19, 119, 19, 51, 19, 68, 19, 186, 42, 0, 0,
+                      221, 49, 11, 0, 101, 53, 8, 0, 168, 76, 8, 0, 80, 100, 9, 0, 5, 226, 84, 65, 1, 0, 81, 4, 25, 0, 1,
+                      4, 147, 4, 164, 3, 144, 3, 45, 4, 91, 15, 91, 15, 83, 15, 38, 15, 0, 0, 0, 0, 171, 201, 10, 0, 153,
+                      125, 8, 0, 35, 124, 8, 0, 135, 250, 9, 0, 130, 213, 59, 65
+            };
+            return to_string(tmp);
+        }
+    };
+
+    /** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
+     * to the values displayed in SAV.
+     *
+     * @note Version 3
+     */
+    struct corrected_intensity_v3 : metric_test<model::metrics::corrected_intensity_metric, 3>
+    {
+        /** Build the expected metric set
+         *
+         * @return vector of metrics
+         */
+        static std::vector<metric_t> metrics()
+        {
+            typedef metric_t::uint_t uint_t;
+            typedef metric_t::ushort_t ushort_t;
+            std::vector<metric_t> metrics;
+            uint_t calledCounts1[] = {52, 1049523, 654071, 500476, 982989};
+            ushort_t correctedIntCalled1[] = {245, 252, 61, 235};
+            //expected_metrics.push_back(metric_type(7, 1114, 1, to_vector(correctedIntCalled1), to_vector(calledCounts1)));
+            metrics.push_back(metric_t(7, 1114, 1, (correctedIntCalled1), (calledCounts1)));
+            uint_t calledCounts2[] = {0, 1063708, 582243, 588028, 953132};
+            ushort_t correctedIntCalled2[] = {232, 257, 68, 228};
+            //expected_metrics.push_back(metric_type(7, 1114, 2, to_vector(correctedIntCalled2), to_vector(calledCounts2)));
+            metrics.push_back(metric_t(7, 1114, 2, (correctedIntCalled2), (calledCounts2)));
+            uint_t calledCounts3[] = {0, 1022928, 617523, 594836, 951825};
+            ushort_t correctedIntCalled3[] = {227, 268, 68, 229};
+            metrics.push_back(metric_t(7, 1114, 3, (correctedIntCalled3), (calledCounts3)));
+            //expected_metrics.push_back(metric_type(7, 1114, 3, to_vector(correctedIntCalled3), to_vector(calledCounts3)));
+            return metrics;
+        }
+        /** Get the expected metric set header
+         *
+         * @return expected metric set header
+         */
+        static header_t header()
+        {
+            return header_t();
+        }
+        /** Get the expected binary data
+         *
+         * @return binary data string
+         */
+        static std::string binary_data()
+        {
+            const int tmp[] = {3, 34, 7, 0, 90, 4, 1, 0, -11, 0, -4, 0, 61, 0, -21, 0, 52, 0, 0, 0, -77, 3, 16, 0, -9, -6, 9, 0,
+                         -4, -94, 7, 0, -51, -1, 14, 0, 7, 0, 90, 4, 2, 0, -24, 0, 1, 1, 68, 0, -28, 0, 0, 0, 0, 0, 28, 59,
+                         16, 0, 99, -30, 8, 0, -4, -8, 8, 0, 44, -117, 14, 0, 7, 0, 90, 4, 3, 0, -29, 0, 12, 1, 68, 0, -27,
+                         0, 0, 0, 0, 0, -48, -101, 15, 0, 51, 108, 9, 0, -108, 19, 9, 0, 17, -122, 14, 0
+            };
+            return to_string(tmp);
+        }
+    };
+    /** Interface between fixtures and Google Test */
+    template<typename TestSetup>
+    struct corrected_intensity_metrics_test : public ::testing::Test, public TestSetup{};
+}}}

--- a/src/tests/interop/metrics/inc/error_metrics_test.h
+++ b/src/tests/interop/metrics/inc/error_metrics_test.h
@@ -1,0 +1,99 @@
+/** Unit tests for the corrected intensity metrics
+ *
+ *
+ *  @file
+ *  @date 3/11/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#pragma once
+#include <gtest/gtest.h>
+#include "metric_test.h"
+#include "interop/model/metrics/error_metric.h"
+#include "interop/model/summary/run_summary.h"
+
+
+namespace illumina{ namespace interop { namespace unittest {
+
+/** This test writes three records of an InterOp files, then reads them back in and compares
+ * each value to ensure they did not change.
+ *
+ * @note Version 3
+ */
+struct error_v3 : metric_test<model::metrics::error_metric, 3>
+{
+    /** Build the expected metric set
+     *
+     * @return vector of metrics
+     */
+    static std::vector<metric_t> metrics()
+    {
+        std::vector<metric_t> expected_metrics;
+
+
+        expected_metrics.push_back(metric_t(7, 1114, 1, 0.450100899f));
+        expected_metrics.push_back(metric_t(7, 1114, 2, 0.900201797f));
+        expected_metrics.push_back(metric_t(7, 1114, 3, 0.465621591f));
+
+        return expected_metrics;
+    }
+    /** Get the expected metric set header
+     *
+     * @return expected metric set header
+     */
+    static header_t header()
+    {
+        return header_t();
+    }
+    /** Get the expected binary data
+     *
+     * @return binary data string
+     */
+    static std::string binary_data()
+    {
+        const int tmp[] = {3,30,7,0,90,4,1,0,-96,115,-26,62,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                ,7,0,90,4,2,0,-96,115,102,63,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                ,7,0,90,4,3,0,-12,101,-18,62,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+        };
+        return to_string(tmp);
+    }
+    /** Get number lanes in data
+     *
+     * @return 8 lanes
+     */
+    static size_t lane_count(){return 8;}
+    /** Get reads describing data
+     *
+     * @return reads vector
+     */
+    static std::vector<model::run::read_info> reads()
+    {
+        std::vector<model::run::read_info> reads(1, model::run::read_info(1, 1, 3, false));
+        return reads;
+    }
+    /** Get the summary for these metrics
+     *
+     * @return run summary
+     */
+    static model::summary::run_summary summary()
+    {
+        std::vector<model::run::read_info> read_infos = reads();
+        model::summary::run_summary summary(read_infos.begin(), read_infos.end(), lane_count());
+        summary[0][6].error_rate()=model::summary::metric_stat(0.67515134811401367f, 0, 0.67515134811401367f);
+        summary[0][6].error_rate_35()=model::summary::metric_stat(0.67515134811401367f, 0, 0.67515134811401367f);
+        summary[0][6].error_rate_50()=model::summary::metric_stat(0.67515134811401367f, 0, 0.67515134811401367f);
+        summary[0][6].error_rate_75()=model::summary::metric_stat(0.67515134811401367f, 0, 0.67515134811401367f);
+        summary[0][6].error_rate_100()=model::summary::metric_stat(0.67515134811401367f, 0, 0.67515134811401367f);
+        summary[0][6].cycle_state().error_cycle_range(model::run::cycle_range(2, 2));
+        summary[0].summary().error_rate(0.67515134811401367f);
+        summary.total_summary().error_rate(0.67515134811401367f);
+        summary[0][6].tile_count(1);
+        summary.cycle_state().error_cycle_range(model::run::cycle_range(2, 2));
+        return summary;
+    }
+};
+
+/** Interface between fixtures and Google Test */
+template<typename TestSetup>
+struct error_metrics_test : public ::testing::Test, public TestSetup{};
+}}}

--- a/src/tests/interop/metrics/inc/extraction_metrics_test.h
+++ b/src/tests/interop/metrics/inc/extraction_metrics_test.h
@@ -1,0 +1,104 @@
+/** Unit tests for the extraction metrics
+ *
+ *
+ *  @file
+ *  @date 3/11/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#pragma once
+#include <gtest/gtest.h>
+#include "metric_test.h"
+#include "interop/model/metrics/extraction_metric.h"
+#include "interop/model/summary/run_summary.h"
+
+
+namespace illumina{ namespace interop { namespace unittest {
+
+    /** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
+     * to the values displayed in SAV.
+     *
+     * @note Version 2
+     */
+    struct extraction_v2 : metric_test<model::metrics::extraction_metric, 2>
+    {
+        enum{
+            /** Do not check the expected binary data */
+           disable_binary_data=true // TODO: Move this to template?
+        };
+        /** Build the expected metric set
+         *
+         * @return vector of metrics
+         */
+        static std::vector<metric_t> metrics()
+        {
+            std::vector<metric_t> expected_metrics;
+
+
+            typedef metric_t::ushort_t ushort_t;
+            const float focus1[] = {2.24664021f, 2.1896739f, 0, 0};
+            const ushort_t p90_1[]  = {302, 273, 0, 0};
+            expected_metrics.push_back(metric_t(7, 1114, 1, interop::util::csharp_date_time(9859129975844165472ul), to_vector(p90_1), to_vector(focus1)));
+            const float focus2[] = {2.23177338f, 2.20616174f, 0, 0};
+            const ushort_t p90_2[]  = {312, 273, 0, 0};
+            expected_metrics.push_back(metric_t(7, 1214, 1, interop::util::csharp_date_time(9859129975872781680ul), to_vector(p90_2), to_vector(focus2)));
+            const float focus3[] = {2.10524225f, 2.14023066f, 0, 0};
+            const ushort_t p90_3[]  = {349, 302, 0, 0};
+            expected_metrics.push_back(metric_t(7, 2114, 1, interop::util::csharp_date_time(9859129975901427921ul), to_vector(p90_3), to_vector(focus3)));
+
+            return expected_metrics;
+        }
+        /** Get the expected metric set header
+         *
+         * @return expected metric set header
+         */
+        static header_t header()
+        {
+            return header_t();
+        }
+        /** Get the expected binary data
+         *
+         * @return binary data string
+         */
+        static std::string binary_data()
+        {
+            const int tmp[] = {2,38,7,0,90,4,1,0,-12,-56,15,64,-98,35,12,64,0,0,0,0,0,0,0,0,46,1,17,1,0,0,0,0,96,-41,-104,36,122,-86,-46,-120
+                    ,7,0,-66,4,1,0,96,-43,14,64,-63,49,13,64,0,0,0,0,0,0,0,0,56,1,17,1,0,0,0,0,112,125,77,38,122,-86,-46,-120
+                    ,7,0,66,8,1,0,74,-68,6,64,-118,-7,8,64,0,0,0,0,0,0,0,0,93,1,46,1,0,0,0,0,-47,-104,2,40,122,-86,-46,-120
+            };
+            return to_string(tmp);
+        }
+        /** Get number lanes in data
+         *
+         * @return 8 lanes
+         */
+        static size_t lane_count(){return 8;}
+        /** Get reads describing data
+         *
+         * @return reads vector
+         */
+        static std::vector<model::run::read_info> reads()
+        {
+            std::vector<model::run::read_info> reads(1, model::run::read_info(1, 1, 2, false));
+            return reads;
+        }
+        /** Get the summary for these metrics
+         *
+         * @return run summary
+         */
+        static model::summary::run_summary summary()
+        {
+            std::vector<model::run::read_info> read_infos = reads();
+            model::summary::run_summary summary(read_infos.begin(), read_infos.end(), lane_count());
+            summary[0][6].first_cycle_intensity()=model::summary::metric_stat(321, 24.75883674621582f, 312);
+            summary[0].summary().first_cycle_intensity(321);
+            summary.total_summary().first_cycle_intensity(321);
+            summary[0][6].tile_count(3);
+            return summary;
+        }
+    };
+
+    /** Interface between fixtures and Google Test */
+    template<typename TestSetup>
+    struct extraction_metrics_test : public ::testing::Test, public TestSetup { };
+}}}

--- a/src/tests/interop/metrics/inc/image_metrics_test.h
+++ b/src/tests/interop/metrics/inc/image_metrics_test.h
@@ -1,0 +1,143 @@
+/** Unit tests for the image metrics
+ *
+ *
+ *  @file
+ *  @date 3/11/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#pragma once
+#include <gtest/gtest.h>
+#include "metric_test.h"
+#include "interop/model/metrics/image_metric.h"
+
+
+namespace illumina{ namespace interop { namespace unittest {
+
+    /** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
+     * to the values displayed in SAV.
+     *
+     * Regression Test: 1947950_117213Bin2R0I
+     *
+     * @note Version 1
+     */
+    struct image_v1 : metric_test<model::metrics::image_metric, 1>
+    {
+        enum{
+            /** Do not check the expected binary data */
+            disable_binary_data=true // TODO: Move this to template?
+        };
+        /** Build the expected metric set
+         *
+         * @return vector of metrics
+         */
+        static std::vector<metric_t> metrics()
+        {
+            std::vector<metric_t> expected_metrics;
+
+
+            typedef metric_t::ushort_t ushort_t;
+            const ushort_t channel_count = metric_t::MAX_CHANNELS;
+            const ushort_t min_contrast1[]  = {896, 1725,738,812};
+            const ushort_t min_contrast2[]  = {908, 1770,739,806};
+            const ushort_t min_contrast3[]  = {923, 1829,734,802};
+
+            const ushort_t max_contrast1[]  = {4840, 8144,3308,4974};
+            const ushort_t max_contrast2[]  = {4829, 8159,3302,4985};
+            const ushort_t max_contrast3[]  = {4829, 8236,3304,4947};
+            expected_metrics.push_back(metric_t(1, 1101, 1, channel_count, to_vector(min_contrast1), to_vector(max_contrast1)));
+            expected_metrics.push_back(metric_t(1, 1102, 1, channel_count, to_vector(min_contrast2), to_vector(max_contrast2)));
+            expected_metrics.push_back(metric_t(1, 1103, 1, channel_count, to_vector(min_contrast3), to_vector(max_contrast3)));
+
+            return expected_metrics;
+        }
+        /** Get the expected metric set header
+         *
+         * @return expected metric set header
+         */
+        static header_t header()
+        {
+            return header_t(metric_t::MAX_CHANNELS);
+        }
+        /** Get the expected binary data
+         *
+         * @return binary data string
+         */
+        static std::string binary_data()
+        {
+            const int tmp[] = {1,12,
+                         1,0,77,4,1,0,0,0,128,3,232,18,
+                         1,0,77,4,1,0,1,0,189,6,208,31,
+                         1,0,77,4,1,0,2,0,226,2,236,12,
+                         1,0,77,4,1,0,3,0,44,3,110,19,
+                         1,0,78,4,1,0,0,0,140,3,221,18,
+                         1,0,78,4,1,0,1,0,234,6,223,31,
+                         1,0,78,4,1,0,2,0,227,2,230,12,
+                         1,0,78,4,1,0,3,0,38,3,121,19,
+                         1,0,79,4,1,0,0,0,155,3,221,18,
+                         1,0,79,4,1,0,1,0,37,7,44,32,
+                         1,0,79,4,1,0,2,0,222,2,232,12,
+                         1,0,79,4,1,0,3,0,34,3,83,19
+            };
+            return to_string(tmp);
+        }
+    };
+    /** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
+     * to the values displayed in SAV.
+     *
+     * @note Version 2
+     */
+    struct image_v2 : metric_test<model::metrics::image_metric, 2>
+    {
+        /** Build the expected metric set
+         *
+         * @return vector of metrics
+         */
+        static std::vector<metric_t> metrics()
+        {
+            std::vector<metric_t> expected_metrics;
+
+
+            typedef metric_t::ushort_t ushort_t;
+            const ushort_t channel_count = 2;
+            const ushort_t min_contrast1[]  = {231, 207};
+            const ushort_t min_contrast2[]  = {229, 205};
+            const ushort_t min_contrast3[]  = {231, 222};
+
+            const ushort_t max_contrast1[]  = {462, 387};
+            const ushort_t max_contrast2[]  = {457, 387};
+            const ushort_t max_contrast3[]  = {473, 416};
+            expected_metrics.push_back(metric_t(7, 1114, 1, channel_count, to_vector(min_contrast1), to_vector(max_contrast1)));
+            expected_metrics.push_back(metric_t(7, 1214, 1, channel_count, to_vector(min_contrast2), to_vector(max_contrast2)));
+            expected_metrics.push_back(metric_t(7, 2114, 1, channel_count, to_vector(min_contrast3), to_vector(max_contrast3)));
+
+
+            return expected_metrics;
+        }
+        /** Get the expected metric set header
+         *
+         * @return expected metric set header
+         */
+        static header_t header()
+        {
+            return header_t(2);
+        }
+        /** Get the expected binary data
+         *
+         * @return binary data string
+         */
+        static std::string binary_data()
+        {
+            const int tmp[] = {2,14,2
+                    ,7,0,90,4,1,0,-25,0,-49,0,-50,1,-125,1
+                    ,7,0,-66,4,1,0,-27,0,-51,0,-55,1,-125,1
+                    ,7,0,66,8,1,0,-25,0,-34,0,-39,1,-96,1
+            };
+            return to_string(tmp);
+        }
+    };
+
+    /** Interface between fixtures and Google Test */
+    template<typename TestSetup>
+    struct image_metrics_test : public ::testing::Test, public TestSetup { };
+}}}

--- a/src/tests/interop/metrics/inc/index_metrics_test.h
+++ b/src/tests/interop/metrics/inc/index_metrics_test.h
@@ -1,0 +1,88 @@
+/** Unit tests for the index metrics
+ *
+ *
+ *  @file
+ *  @date 3/11/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#pragma once
+#include <gtest/gtest.h>
+#include "metric_test.h"
+#include "interop/model/metrics/index_metric.h"
+
+
+namespace illumina{ namespace interop { namespace unittest {
+
+    /** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
+     * to the values displayed in SAV.
+     *
+     * This metric was artificially changed to give it three unique records. The lane was changed from 1 to 2 and 3
+     * for the second and third records.
+     *
+     * @note Version 1
+     */
+    struct index_v1 : metric_test<model::metrics::index_metric, 1>
+    {
+        enum{
+            /** Do not check record size (does not have it)*/
+            disable_check_record_size=true,
+            /** Do not check the expected binary data size */
+            disable_binary_data_size=true
+        };
+        /** Build the expected metric set
+         *
+         * @return vector of metrics
+         */
+        static std::vector<metric_t> metrics()
+        {
+            std::vector<metric_t> expected_metrics;
+            typedef metric_t::index_info_t index_info_t;
+
+
+            metric_t::index_array_t indices1;
+            indices1.push_back(index_info_t("ATCACGAC-AAGGTTCA", "1", "TSCAIndexes", 4570));
+            expected_metrics.push_back(metric_t(1, 12106, 3, indices1));
+            metric_t::index_array_t indices2;
+            indices2.push_back(index_info_t("ACAGTGGT-AAGGTTCA", "2", "TSCAIndexes", 4477));
+            expected_metrics.push_back(metric_t(2, 12106, 3, indices2));
+            metric_t::index_array_t indices3;
+            indices3.push_back(index_info_t("CAGATCCA-AAGGTTCA", "3", "TSCAIndexes", 4578));
+            expected_metrics.push_back(metric_t(3, 12106, 3, indices3));
+
+            return expected_metrics;
+        }
+        /** Get the expected metric set header
+         *
+         * @return expected metric set header
+         */
+        static header_t header()
+        {
+            return header_t();
+        }
+        /** Get the expected binary data
+         *
+         * @return binary data string
+         */
+        static std::string binary_data()
+        {
+            const int tmp[] = {1
+                    ,1,0,74,47,3,0
+                    ,17,0,65,84,67,65,67,71,65,67,45,65,65,71,71,84,84,67,65,218,17,0,0,1,0,49,11,0,84,83,67,65,73,110
+                    ,100,101,120,101,115
+                    ,2,0,74,47,3,0 // changed to lane 2
+                    ,17,0,65,67,65,71,84,71,71,84,45,65,65,71,71,84,84,67,65,125,17,0,0,1,0,50,11,0,84,83,67,65,73,110
+                    ,100,101,120,101,115
+                    ,3,0,74,47,3,0 // changed to lane 3
+                    ,17,0,67,65,71,65,84,67,67,65,45,65,65,71,71,84,84,67,65,226,17,0,0,1,0,51,11,0,84,83,67,65,73,110
+                    ,100,101,120,101,115
+            };
+            return to_string(tmp);
+        }
+
+    };
+
+    /** Interface between fixtures and Google Test */
+    template<typename TestSetup>
+    struct index_metrics_test : public ::testing::Test, public TestSetup { };
+}}}

--- a/src/tests/interop/metrics/inc/metric_test.h
+++ b/src/tests/interop/metrics/inc/metric_test.h
@@ -1,0 +1,197 @@
+/** Utility class for setting up a basic data fixture
+ *
+ *
+ *  @file
+ *  @date 3/10/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#pragma once
+#include <string>
+#include <vector>
+#include "interop/model/metric_base/metric_set.h"
+#include "interop/io/metric_file_stream.h"
+
+namespace illumina{ namespace interop { namespace unittest {
+
+    /** Sparse representation
+     */
+    template<class T, size_t Size>
+    struct sparse_value
+    {
+        /** Constructor
+         *
+         * @param o index
+         * @param v value
+         */
+        sparse_value(size_t o, T v) : offset(o), value(v)
+        { }
+
+        /** Index */
+        size_t offset;
+        /** Value */
+        T value;
+    };
+
+    /** Generic metric set structure
+     */
+    template<class Metric, int Version>
+    class metric_test
+    {
+    public:
+        enum
+        {
+            /** Version of the format */
+            VERSION=Version,
+            /** Check record size */
+            disable_check_record_size = false,
+            /** Check the size of the expected written binary data */
+            disable_binary_data_size = false,
+            /** Check the expected written binary data */
+            disable_binary_data = false
+        };
+    public:
+        /** Metric type */
+        typedef Metric metric_t;
+        /** Metric set type */
+        typedef model::metric_base::metric_set<Metric> metric_set_t;
+        /** Metric set header type */
+        typedef typename metric_t::header_type header_t;
+        /** Constant iterator over metrics */
+        typedef typename metric_set_t::const_iterator const_iterator;
+
+    public:
+        /** Convert an array to a vector
+         *
+         * Determines the length of the stack array automatically.
+         *
+         * @param vals array pointer
+         * @return vector of values
+         */
+        template<typename T, size_t N>
+        static std::vector<T> to_vector(const T (&vals)[N])
+        {
+            return std::vector<T>(vals, vals + N);
+        }
+        /** Get size of stack array
+         *
+         * Determines the length of the stack array automatically.
+         *
+         * @return size of stack array
+         */
+        template<typename T, size_t N>
+        static size_t size_of(const T (&)[N])
+        {
+            return N;
+        }
+        /** Convert an array to a vector
+         *
+         * Determines the length of the stack array automatically.
+         *
+         * @param vals array pointer
+         * @return vector of values
+         */
+        template<typename T, size_t N, size_t Size>
+        static std::vector<T> to_vector(const sparse_value<T, Size> (&vals)[N])
+        {
+            std::vector<T> vec(Size, 0);
+            for (size_t i = 0; i < N; i++)
+                vec[vals[i].offset] = vals[i].value;
+            return vec;
+        }
+        /** Set expected binary data
+         *
+         * @param tmp int array of byte values
+         * @return string of byte values
+         */
+        template<size_t N>
+        static std::string to_string(const int (&tmp)[N])
+        {
+            std::string binary_data="";
+            for (size_t i = 0; i < N; ++i) binary_data += char(tmp[i]);
+            return binary_data;
+        }
+    };
+
+    /** Generic fixture base class */
+    template<class Gen>
+    struct metric_test_fixture : public Gen
+    {
+        /** Metric type */
+        typedef typename Gen::metric_t metric_t;
+        /** Metric set type */
+        typedef typename Gen::metric_set_t metric_set_t;
+        /** Constructor
+         *
+         */
+        metric_test_fixture() : expected_metric_set(Gen::metrics(), Gen::VERSION, Gen::header()),
+                expected_binary_data(Gen::binary_data())
+        {
+        }
+        /** Read metrics from a binary buffer
+         *
+         * @param data binary buffer
+         * @param metrics metric set
+         */
+        static void read_metrics(const std::string& data, metric_set_t& metrics)
+        {
+            try
+            {
+                std::istringstream fin(data);
+                illumina::interop::io::read_metrics(fin, metrics);
+            }
+            catch (const std::exception &) { }
+        }
+
+    public:
+        /** Expected metric set */
+        metric_set_t expected_metric_set;
+        /** Expected buffer of binary metric data */
+        std::string expected_binary_data;
+        /** Actual metric set */
+        metric_set_t actual_metric_set;
+        /** Actual buffer of binary metric data */
+        std::string actual_binary_data;
+    };
+
+    /** Setup up a hardcoded metric test */
+    template<class T>
+    class hardcoded_fixture : public metric_test_fixture<T>
+    {
+        typedef metric_test_fixture<T> fixture_t;
+    public:
+        /** Construct hard coded test */
+        hardcoded_fixture()
+        {
+            fixture_t::read_metrics(fixture_t::expected_binary_data,fixture_t::actual_metric_set);
+            std::ostringstream fout;
+            illumina::interop::io::write_metrics(fout, fixture_t::actual_metric_set, T::VERSION);
+            fixture_t::actual_binary_data = fout.str();
+        }
+    };
+
+    /** Sets up a write read test */
+    template<class T>
+    class write_read_fixture : public metric_test_fixture<T>
+    {
+        typedef metric_test_fixture<T> fixture_t;
+    public:
+        /** Construct write read test */
+        write_read_fixture()
+        {
+            {
+                std::ostringstream fout;
+                illumina::interop::io::write_metrics(fout, fixture_t::expected_metric_set, T::VERSION);
+                fixture_t::expected_binary_data = fout.str();
+            }
+            fixture_t::read_metrics(fixture_t::expected_binary_data,fixture_t::actual_metric_set);
+            {
+                std::ostringstream fout;
+                illumina::interop::io::write_metrics(fout, fixture_t::actual_metric_set, T::VERSION);
+                fixture_t::actual_binary_data = fout.str();
+            }
+        }
+    };
+
+
+}}}

--- a/src/tests/interop/metrics/inc/q_metrics_test.h
+++ b/src/tests/interop/metrics/inc/q_metrics_test.h
@@ -1,0 +1,331 @@
+/** Unit tests for the extraction metrics
+ *
+ *
+ *  @file
+ *  @date 3/11/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#pragma once
+#include <gtest/gtest.h>
+#include "metric_test.h"
+#include "interop/model/metrics/q_metric.h"
+#include "interop/model/summary/run_summary.h"
+
+
+namespace illumina{ namespace interop { namespace unittest {
+    /** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
+     * to the values displayed in SAV.
+     *
+     * Regression set: 1947950_117213Bin2R0I
+     *
+     * @note Version 4
+     */
+    struct q_v4 : metric_test<model::metrics::q_metric, 4>
+    {
+        /** Build the expected metric set
+         *
+         * @return vector of metrics
+         */
+        static std::vector<metric_t> metrics()
+        {
+            std::vector<metric_t> expected_metrics;
+
+
+            typedef metric_t::uint_t uint_t;
+            typedef sparse_value<uint_t, metric_t::MAX_Q_BINS> q_val;
+
+            const q_val hist1[] = {q_val(14,21208), q_val(21,8227), q_val(26,73051), q_val(32,2339486)};
+            const q_val hist2[] = {q_val(14,22647), q_val(21,9570), q_val(26,81839), q_val(32,2413227)};
+            const q_val hist3[] = {q_val(14,18878), q_val(21,8168), q_val(26,72634), q_val(32,2342292)};
+
+            expected_metrics.push_back(metric_t(1, 1104, 1, to_vector(hist1)));
+            expected_metrics.push_back(metric_t(1, 1106, 1, to_vector(hist2)));
+            expected_metrics.push_back(metric_t(1, 1104, 2, to_vector(hist3)));
+
+
+            return expected_metrics;
+        }
+        /** Get the expected metric set header
+         *
+         * @return expected metric set header
+         */
+        static header_t header()
+        {
+            typedef header_t::qscore_bin_vector_type qscore_bin_vector_type;
+            qscore_bin_vector_type headervec;
+            return header_t(headervec);
+        }
+        /** Get the expected binary data
+         *
+         * @return binary data string
+         */
+        static std::string binary_data()
+        {
+            const int tmp[] = {
+                    4,206,
+                    1,0,80,4,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,216,82,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,35,32,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,91
+                    ,29,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,158,178,35,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                    1,0,82,4,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,119,88,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,98,37,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,175,63,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,171,210,36,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                    1,0,80,4,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,190,73,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,232,31,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,186,27,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,148,189,35,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0
+            };
+            return to_string(tmp);
+        }
+        /** Get number lanes in data
+         *
+         * @return 8 lanes
+         */
+        static size_t lane_count(){return 8;}
+        /** Get reads describing data
+         *
+         * @return reads vector
+         */
+        static std::vector<model::run::read_info> reads()
+        {
+            std::vector<model::run::read_info> reads(1, model::run::read_info(1, 1, 3, false));
+            return reads;
+        }
+        /** Get the summary for these metrics
+         *
+         * @return run summary
+         */
+        static model::summary::run_summary summary()
+        {
+            std::vector<model::run::read_info> read_infos = reads();
+            model::summary::run_summary summary(read_infos.begin(), read_infos.end(), lane_count());
+            summary[0][0].tile_count(2);
+            summary[0][0].projected_yield_g(0.0098816361278295517);
+            summary[0][0].yield_g(0.0074112270958721638f);
+            summary[0][0].percent_gt_q30(95.733200073242188f);
+            summary[0].summary().projected_yield_g(0.0098816361278295517);
+            summary[0].summary().yield_g(0.0074112270958721638f);
+            summary[0].summary().percent_gt_q30(95.733200073242188f);
+            summary.total_summary().percent_gt_q30(95.733200073242188f);
+            summary.total_summary().projected_yield_g(0.0098816361278295517);
+            summary.total_summary().yield_g(0.0074112270958721638f);
+            return summary;
+        }
+    };
+
+    /** This test writes three records of an InterOp files, then reads them back in and compares
+     * each value to ensure they did not change.
+     *
+     * @note Version 5
+     */
+    struct q_v5 : metric_test<model::metrics::q_metric, 5> // TODO: Add binned
+    {
+        /** Build the expected metric set
+         *
+         * @return vector of metrics
+         */
+        static std::vector<metric_t> metrics()
+        {
+            std::vector<metric_t> expected_metrics;
+
+            typedef metric_t::uint_t uint_t;
+            typedef sparse_value<uint_t, 7> q_val;
+
+            const q_val hist1[] = {q_val(1,45272), q_val(3,33369), q_val(4,1784241)};
+            const q_val hist2[] = {q_val(1,45229), q_val(3,34304), q_val(4,1792186)};
+            const q_val hist3[] = {q_val(1,49152), q_val(3,37440), q_val(4,1806479)};
+
+            expected_metrics.push_back(metric_t(1, 1103, 1, to_vector(hist1)));
+            expected_metrics.push_back(metric_t(1, 1104, 1, to_vector(hist2)));
+            expected_metrics.push_back(metric_t(1, 1108, 1, to_vector(hist3)));
+
+            return expected_metrics;
+        }
+        /** Get the expected metric set header
+         *
+         * @return expected metric set header
+         */
+        static header_t header()
+        {
+            typedef header_t::qscore_bin_vector_type qscore_bin_vector_type;
+            typedef header_t::bin_t bin_t;
+            typedef bin_t::bin_type ushort_t;
+            typedef metric_t::uint_t uint_t;
+            const uint_t bin_count = 7;
+            ushort_t lower[] = {1, 10, 20, 25, 30, 35, 40};
+            ushort_t upper[] = {9, 19, 24, 29, 34, 39, 41};
+            ushort_t value[] = {1, 14, 22, 27, 33, 37, 40};
+            qscore_bin_vector_type headervec;
+            for(uint_t i=0;i<bin_count;i++)
+                headervec.push_back(bin_t(lower[i], upper[i], value[i]));
+            return header_t(headervec);
+        }
+        /** Get the expected binary data
+         *
+         * @return binary data string
+         */
+        static std::string binary_data()
+        {
+            const int tmp[] = {
+                    5,206,
+                    1,7,
+                    1,10,20,25,30,35,40,9,19,24,29,34,39,41,1,14,22,27,33,37,40,
+                    1,0,79,4,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,216,176,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,89,130,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,177,57,27,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,
+                    1,0,80,4,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,173,176,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,134,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,186,88,27,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,
+                    1,0,84,4,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,192,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,64,146,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,143,144,27,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+            };
+            return to_string(tmp);
+        }
+        /** Get number lanes in data
+         *
+         * @return 8 lanes
+         */
+        static size_t lane_count(){return 8;}
+        /** Get reads describing data
+         *
+         * @return reads vector
+         */
+        static std::vector<model::run::read_info> reads()
+        {
+            std::vector<model::run::read_info> reads(1, model::run::read_info(1, 1, 2, false));
+            return reads;
+        }
+        /** Get the summary for these metrics
+         *
+         * @return run summary
+         */
+        static model::summary::run_summary summary()
+        {
+            std::vector<model::run::read_info> read_infos = reads();
+            model::summary::run_summary summary(read_infos.begin(), read_infos.end(), lane_count());
+            summary[0][0].tile_count(3);
+            summary[0][0].projected_yield_g(0.0056276721879839897f);
+            summary[0][0].yield_g(0.0056276721879839897f);
+            summary[0][0].percent_gt_q30(95.650672912597656f);
+            summary[0].summary().projected_yield_g(0.0056276721879839897f);
+            summary[0].summary().yield_g(0.0056276721879839897f);
+            summary[0].summary().percent_gt_q30(95.650672912597656f);
+            summary.total_summary().percent_gt_q30(95.650672912597656f);
+            summary.total_summary().projected_yield_g(0.0056276721879839897f);
+            summary.total_summary().yield_g(0.0056276721879839897);
+            return summary;
+        }
+    };
+
+    /** This test writes three records of an InterOp files, then reads them back in and compares
+     * each value to ensure they did not change.
+     *
+     * @note Version 6
+     */
+    struct q_v6 : metric_test<model::metrics::q_metric, 6>
+    {
+        /** Build the expected metric set
+         *
+         * @return vector of metrics
+         */
+        static std::vector<metric_t> metrics()
+        {
+            std::vector<metric_t> expected_metrics;
+            typedef metric_t::uint_t uint_t;
+
+            const uint_t hist_all1[] = {0, 267962, 118703, 4284, 2796110, 0, 0};
+            const uint_t hist_all2[] = {0,241483, 44960, 1100, 2899568, 0 ,0};
+            const uint_t hist_all3[] = {0,212144, 53942, 427, 2920598, 0, 0};
+            std::vector<uint_t> hist_tmp(50, 0);
+
+            expected_metrics.push_back(metric_t(7, 1114, 1, to_vector(hist_all1)));
+            expected_metrics.push_back(metric_t(7, 1114, 2, to_vector(hist_all2)));
+            expected_metrics.push_back(metric_t(7, 1114, 3,to_vector(hist_all3)));
+
+            return expected_metrics;
+        }
+        /** Get the expected metric set header
+         *
+         * @return expected metric set header
+         */
+        static header_t header()
+        {;
+            typedef header_t::qscore_bin_vector_type qscore_bin_vector_type;
+            typedef header_t::bin_t bin_t;
+            typedef bin_t::bin_type ushort_t;
+            typedef metric_t::uint_t uint_t;
+            const uint_t bin_count = 7;
+
+            const ushort_t lower[] = {2, 10, 20, 25, 30, 35, 40};
+            const ushort_t upper[] = {9, 19, 24, 29, 34, 39, 40};
+            const ushort_t value[] = {2, 14, 21, 27, 32, 36, 40};
+            qscore_bin_vector_type headervec;
+            for(uint_t i=0;i<bin_count;i++)
+                headervec.push_back(bin_t(lower[i], upper[i], value[i]));
+            return header_t(headervec);
+        }
+        /** Get the expected binary data
+         *
+         * @return binary data string
+         */
+        static std::string binary_data()
+        {
+            const int tmp[] = {
+                    6,34,1,7,2,10,20,25,30,35,40,9,19,24,29,34,39,40,2,14,21,27,32,36,40
+                    ,7,0,90,4,1,0,0,0,0,0,-70,22,4,0,-81,-49,1,0,-68,16,0,0,78,-86,42,0,0,0,0,0,0,0,0,0
+                    ,7,0,90,4,2,0,0,0,0,0,75,-81,3,0,-96,-81,0,0,76,4,0,0,112,62,44,0,0,0,0,0,0,0,0,0
+                    ,7,0,90,4,3,0,0,0,0,0,-80,60,3,0,-74,-46,0,0,-85,1,0,0,-106,-112,44,0,0,0,0,0,0,0,0,0
+            };
+            return to_string(tmp);
+        }
+        /** Get number lanes in data
+         *
+         * @return 8 lanes
+         */
+        static size_t lane_count(){return 8;}
+        /** Get reads describing data
+         *
+         * @return reads vector
+         */
+        static std::vector<model::run::read_info> reads()
+        {
+            std::vector<model::run::read_info> reads(1, model::run::read_info(1, 1, 4, false));
+            return reads;
+        }
+        /** Get the summary for these metrics
+         *
+         * @return run summary
+         */
+        static model::summary::run_summary summary()
+        {
+            std::vector<model::run::read_info> read_infos = reads();
+            model::summary::run_summary summary(read_infos.begin(), read_infos.end(), lane_count());
+            summary[0][6].tile_count(1);
+            summary[0][6].projected_yield_g(0.0095612816512584686f);
+            summary[0][6].yield_g(0.009561280719935894f);
+            summary[0][6].percent_gt_q30(90.1163330078125f);
+            summary[0].summary().projected_yield_g(0.0095612816512584686f);
+            summary[0].summary().yield_g(0.0095612816512584686f);
+            summary[0].summary().percent_gt_q30(90.1163330078125f);
+            summary.total_summary().percent_gt_q30(90.1163330078125f);
+            summary.total_summary().projected_yield_g(0.0095612816512584686f);
+            summary.total_summary().yield_g(0.0095612816512584686f);
+            return summary;
+        }
+    };
+
+    /** Interface between fixtures and Google Test */
+    template<typename TestSetup>
+    struct q_metrics_test : public ::testing::Test, public TestSetup { };
+}}}

--- a/src/tests/interop/metrics/inc/stream_tests.hpp
+++ b/src/tests/interop/metrics/inc/stream_tests.hpp
@@ -1,0 +1,131 @@
+/** Unit tests for various failure conditions handled by exceptions.
+ *
+ *
+ *  @file
+ *
+ *  @date 10/6/2015
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4127) // MSVC warns about using constants in conditional statements, for template constants
+#endif
+
+/** Wrapper for X-Macro FIXTURE
+ *
+ */
+#define WRAPPED_TEST(FIXTURE, FUNC) TYPED_TEST(FIXTURE, FUNC)
+
+/**
+ * Confirm binary write matches expected binary data
+ */
+WRAPPED_TEST(FIXTURE, test_expected_get_metric)
+{
+    typename TypeParam::metric_set_t::key_vector keys = TypeParam::actual_metric_set.keys();
+    for(size_t i=0;i<keys.size();i++)
+    {
+        EXPECT_EQ(keys[i], TypeParam::actual_metric_set.get_metric(keys[i]).id());
+    }
+}
+
+/**
+ * Confirm binary write matches expected binary data
+ */
+WRAPPED_TEST(FIXTURE, test_write_read_binary_data)
+{
+    if(TypeParam::disable_binary_data_size) return;
+    EXPECT_EQ(TypeParam::expected_binary_data.size(), TypeParam::actual_binary_data.size());
+    if(TypeParam::disable_binary_data) return;
+    for(::uint32_t i=0;i<std::min(TypeParam::expected_binary_data.size(), TypeParam::actual_binary_data.size());i++)
+    {
+        //if(TypeParam::expected_binary_data[i] != TypeParam::actual_binary_data[i])
+        //    std::cerr << i << " " << int(TypeParam::expected_binary_data[i]) << " != " <<  int(TypeParam::actual_binary_data[i]) << std::endl;
+        EXPECT_EQ(int(TypeParam::expected_binary_data[i]), int(TypeParam::actual_binary_data[i]));
+        //BOOST_CHECK_MESSAGE(TypeParam::expected_binary_data[i] == TypeParam::actual_binary_data[i], "i=" << i << " - " << int(TypeParam::expected_binary_data[i]) << " == " << int(TypeParam::actual_binary_data[i]) << " - " << TypeParam::VERSION);
+    }
+}
+
+/** Confirm bad_format_exception is thrown when version is unsupported
+ */
+WRAPPED_TEST(FIXTURE, test_hardcoded_bad_format_exception)
+{
+    std::string tmp = std::string(TypeParam::expected_binary_data);
+    tmp[0] = 34;
+    std::istringstream fin(tmp);
+    typename TypeParam::metric_set_t metrics;
+    EXPECT_THROW(illumina::interop::io::read_metrics(fin, metrics), bad_format_exception);
+}
+
+/** Confirm incomplete_file_exception is thrown for a small partial record
+ */
+WRAPPED_TEST(FIXTURE, test_hardcoded_incomplete_file_exception)
+{
+    ::uint32_t incomplete = 0;
+    for(::uint32_t i=2;i<25;i++)
+    {
+        std::istringstream fin(TypeParam::expected_binary_data.substr(0, i));
+        typename TypeParam::metric_set_t metrics;
+        try{
+            illumina::interop::io::read_metrics(fin, metrics);
+        }
+        catch(const incomplete_file_exception&){incomplete++;}
+        catch(const std::exception& ex){ std::cerr << i << " " << ex.what() << std::endl;throw;}
+    }
+    EXPECT_TRUE(incomplete>10);
+}
+/** Confirm incomplete_file_exception is thrown for a mostly complete file
+ */
+WRAPPED_TEST(FIXTURE, test_hardcoded_incomplete_file_exception_last_metric)
+{
+    std::istringstream fin(TypeParam::expected_binary_data.substr(0,TypeParam::expected_binary_data.length()-4));
+    typename TypeParam::metric_set_t metrics;
+    EXPECT_THROW(illumina::interop::io::read_metrics(fin, metrics), incomplete_file_exception);
+}
+/** Confirm bad_format_exception is thrown when record size is incorrect
+ */
+WRAPPED_TEST(FIXTURE, test_hardcoded_incorrect_record_size)
+{
+    if(TypeParam::disable_check_record_size) return;
+    std::string tmp = std::string(TypeParam::expected_binary_data);
+    tmp[1] = 0;
+    std::istringstream fin(tmp);
+    typename TypeParam::metric_set_t metrics;
+    EXPECT_THROW(illumina::interop::io::read_metrics(fin, metrics), bad_format_exception);
+}
+/** Confirm file_not_found_exception is thrown when a file is not found
+ */
+WRAPPED_TEST(FIXTURE, test_hardcoded_file_not_found)
+{
+    typename TypeParam::metric_set_t metrics;
+    EXPECT_THROW(illumina::interop::io::read_interop("/NO/FILE/EXISTS", metrics), file_not_found_exception);
+}
+/** Confirm reading from good data does not throw an exception
+ */
+WRAPPED_TEST(FIXTURE, test_hardcoded_read)
+{
+    std::string tmp = std::string(TypeParam::expected_binary_data);
+    std::istringstream fin(tmp);
+    typename TypeParam::metric_set_t metrics;
+    EXPECT_NO_THROW(illumina::interop::io::read_metrics(fin, metrics));
+}
+/** Confirm the clear function works
+ */
+WRAPPED_TEST(FIXTURE, test_clear)
+{
+    std::string tmp = std::string(TypeParam::expected_binary_data);
+    std::istringstream fin(tmp);
+    typename TypeParam::metric_set_t metrics;
+    EXPECT_NO_THROW(illumina::interop::io::read_metrics(fin, metrics));
+    size_t cnt = metrics.size();
+    metrics.clear();
+    std::istringstream fin2(tmp);
+    EXPECT_NO_THROW(illumina::interop::io::read_metrics(fin2, metrics));
+    EXPECT_EQ(cnt, metrics.size());
+
+}
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/src/tests/interop/metrics/inc/summary_fixture.h
+++ b/src/tests/interop/metrics/inc/summary_fixture.h
@@ -1,0 +1,47 @@
+/** Run summary test fixture
+ *
+ *  @file
+ *  @date 3/11/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+
+#pragma once
+#include <sstream>
+#include "interop/logic/summary/run_summary.h"
+
+namespace illumina{ namespace interop { namespace unittest {
+    /** Fixture for the run summary*/
+    template<class Gen>
+    struct summary_fixture
+    {
+        /** Constructor */
+        summary_fixture(std::vector<model::run::read_info> reads = Gen::reads()) :
+                expected(Gen::summary()),
+                actual(reads.begin(), reads.end(), Gen::lane_count())
+        {
+            std::vector<std::string> channels;
+            channels.push_back("Red");
+            channels.push_back("Green");
+            model::run::info run_info("XX",
+                                      "",
+                                      1,
+                                      model::run::flowcell_layout(Gen::lane_count()),
+                                      channels,
+                                      model::run::image_dimensions(),
+                                      reads);
+            model::metrics::run_metrics metrics(run_info);
+            try
+            {
+                std::istringstream fin(Gen::binary_data());
+                illumina::interop::io::read_metrics(fin, metrics.get_set<typename Gen::metric_t>());
+            }
+            catch (const std::exception &) { }
+            logic::summary::summarize_run_metrics(metrics, actual);
+        }
+        /** Expected run summary */
+        model::summary::run_summary expected;
+        /** Actual run summary derived from hardcoded binary data */
+        model::summary::run_summary actual;
+    };
+}}}

--- a/src/tests/interop/metrics/inc/tile_metrics_test.h
+++ b/src/tests/interop/metrics/inc/tile_metrics_test.h
@@ -1,0 +1,156 @@
+/** Unit tests for the tile metrics
+ *
+ *
+ *  @file
+ *  @date 3/12/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#pragma once
+#include <gtest/gtest.h>
+#include "metric_test.h"
+#include "interop/model/metrics/tile_metric.h"
+#include "interop/model/summary/run_summary.h"
+
+
+namespace illumina{ namespace interop { namespace unittest {
+
+    /** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
+     * to the values displayed in SAV.
+     *
+     * @note Version 2
+     */
+    struct tile_v2 : metric_test<model::metrics::tile_metric, 2>
+    {
+        enum{
+            /** Do not check the expected binary data */
+            disable_binary_data=true,
+            /** Do not check the expected binary data size */
+            disable_binary_data_size=true
+        };
+        /** Build the expected metric set
+         *
+         * @return vector of metrics
+         */
+        static std::vector<metric_t> metrics()
+        {
+            std::vector<metric_t> expected_metrics;
+
+
+            metric_t::read_metric_vector reads1;
+            reads1.push_back(metric_t::read_metric_type(1, 2.61630869f, 0.0797112584f, 0.119908921f));
+            reads1.push_back(metric_t::read_metric_type(2, 2.61630869f, 0.0797112584f, 0.119908921f));
+
+            expected_metrics.push_back(metric_t(7, 1114, 2355119.25f,1158081.50f,6470949,3181956,reads1));
+            expected_metrics.push_back(metric_t(7, 1214, 2355119.25f,1174757.75f,6470949,3227776,
+                                                metric_t::read_metric_vector(1, metric_t::read_metric_type(1, 2.62243795f, 0.129267812f, 0.135128692f))));
+            expected_metrics.push_back(metric_t(7, 2114, 2355119.25f,1211592.38f,6470949,3328983,
+                                                metric_t::read_metric_vector(1, metric_t::read_metric_type(1, 2.490309f, 0.11908555f, 0.092706576f))));
+
+            return expected_metrics;
+        }
+        /** Get the expected metric set header
+         *
+         * @return expected metric set header
+         */
+        static header_t header()
+        {
+            return header_t();
+        }
+        /** Get the expected binary data
+         *
+         * @return binary data string
+         */
+        static std::string binary_data()
+        {
+            const int tmp[] = {
+                    2,10
+                    ,7,0,90,4,100,0,-67,-66,15,74
+                    ,7,0,90,4,102,0,74,122,-59,74
+                    ,7,0,90,4,101,0,12,94,-115,73
+                    ,7,0,90,4,103,0,16,54,66,74
+                    ,7,0,90,4,-56,0,82,-11,80,58
+                    ,7,0,90,4,-55,0,-62,42,-99,58
+                    ,7,0,90,4,44,1,-102,113,39,64
+                    ,7,0,90,4,-54,0,82,-11,80,58
+                    ,7,0,90,4,-53,0,-62,42,-99,58
+                    ,7,0,90,4,45,1,-102,113,39,64
+                    ,7,0,90,4,-56,0,82,-11,80,58
+                    ,7,0,90,4,-55,0,-62,42,-99,58
+                    ,7,0,90,4,44,1,-102,113,39,64
+                    ,7,0,-66,4,100,0,-67,-66,15,74
+                    ,7,0,-66,4,102,0,74,122,-59,74
+                    ,7,0,-66,4,101,0,46,103,-113,73
+                    ,7,0,-66,4,103,0,0,2,69,74
+                    ,7,0,-66,4,-56,0,21,111,-87,58
+                    ,7,0,-66,4,-55,0,-86,29,-79,58
+                    ,7,0,-66,4,44,1,6,-42,39,64
+                    ,7,0,66,8,100,0,-67,-66,15,74
+                    ,7,0,66,8,102,0,74,122,-59,74
+                    ,7,0,66,8,101,0,67,-26,-109,73
+                    ,7,0,66,8,103,0,92,47,75,74
+                    ,7,0,66,8,-56,0,123,22,-100,58
+                    ,7,0,66,8,-55,0,85,6,115,58
+                    ,7,0,66,8,44,1,57,97,31,64
+                    ,7,0,66,8,144,1,0,0,0,0   // Test whether control lane accidentally clears data
+                    ,6,0,66,8,144,1,0,0,0,0   // Test whether control lane for empty tile shows up
+            };
+            return to_string(tmp);
+        }
+        /** Get number lanes in data
+         *
+         * @return 8 lanes
+         */
+        static size_t lane_count(){return 8;}
+        /** Get reads describing data
+         *
+         * @return reads vector
+         */
+        static std::vector<model::run::read_info> reads()
+        {
+            std::vector<model::run::read_info> reads;
+            reads.reserve(2);
+            reads.push_back(model::run::read_info(1, 1, 3, false));
+            reads.push_back(model::run::read_info(2, 1, 3, false));
+            return reads;
+        }
+        /** Get the summary for these metrics
+         *
+         * @return run summary
+         */
+        static model::summary::run_summary summary()
+        {
+            std::vector<model::run::read_info> read_infos = reads();
+            model::summary::run_summary summary(read_infos.begin(), read_infos.end(), lane_count());
+            for(size_t read=0;read<read_infos.size();++read)
+            {
+                summary[read][6].tile_count(3);
+                summary[read][6].reads_pf(9738715);
+                summary[read][6].reads(19412848);
+                summary[read][6].density() = model::summary::metric_stat(2355119.25f, 0, 2355119.25f);
+                summary[read][6].density_pf() = model::summary::metric_stat(1181477.125f, 27380.955078125f, 1174757.75f);
+                summary[read][6].cluster_count() = model::summary::metric_stat(6470949.5f, 0, 6470949);
+                summary[read][6].cluster_count_pf() = model::summary::metric_stat(3246238.25f, 75232.1640625f, 3227776);
+                summary[read][6].percent_pf() = model::summary::metric_stat(50.166339874267578f, 1.1626163721084595f, 49.881031036376953f);
+            }
+            summary[0][6].phasing() = model::summary::metric_stat(0.10935487598180771f, 0.026172075420618057f, 0.11908555030822754f);
+            summary[0][6].prephasing() = model::summary::metric_stat(0.1159147247672081f, 0.021491257473826408f, 0.11990892142057419f);
+            summary[0][6].percent_aligned() = model::summary::metric_stat(2.5763518810272217f, 0.074578315019607544f, 2.6163086891174316f);
+
+            summary[1][6].phasing() = model::summary::metric_stat(0.079711258411407471f, 0, 0.079711258411407471f);
+            summary[1][6].prephasing() = model::summary::metric_stat(0.11990892142057419f, 0, 0.11990892142057419f);
+            summary[1][6].percent_aligned() = model::summary::metric_stat(2.6163086891174316, 0, 2.6163086891174316f);
+
+            summary[0].summary().percent_aligned(2.5763518810272217f);
+            summary[1].summary().percent_aligned(2.6163086891174316f);
+            summary.total_summary().percent_aligned(2.5863409042358398f);
+
+            return summary;
+        }
+    };
+
+    /** Interface between fixtures and Google Test */
+    template<typename TestSetup>
+    struct tile_metrics_test : public ::testing::Test, public TestSetup { };
+}}}
+

--- a/src/tests/interop/metrics/index_metrics_test.cpp
+++ b/src/tests/interop/metrics/index_metrics_test.cpp
@@ -2,7 +2,6 @@
  *
  *
  *  @file
- *
  *  @date 11/4/15
  *  @version 1.0
  *  @copyright GNU Public License.
@@ -10,95 +9,14 @@
 
 #include <fstream>
 #include <gtest/gtest.h>
-#include "interop/model/metric_sets/index_metric_set.h"
-#include "src/tests/interop/metrics/metric_test_utils.h"
+#include "inc/index_metrics_test.h"
 using namespace illumina::interop::model::metrics;
 using namespace illumina::interop::io;
-
-
-namespace illumina{ namespace interop { namespace unittest {
-/** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
- * to the values displayed in SAV.
- *
- * This metric was artificially changed to give it three unique records. The lane was changed from 1 to 2 and 3
- * for the second and third records.
- *
- * @note Version 1
- */
-struct index_metrics_hardcoded_fixture_v1 : util::fixture_helper<index_metrics, 1>
-{
-    enum{
-        /** Do not check record size (does not have it)*/
-        disable_check_record_size=true,
-        /** Do not check the expected binary data size */
-        disable_binary_data_size=true
-    };
-    /** Setup fixture */
-    index_metrics_hardcoded_fixture_v1()
-    {
-        index_metric::index_array_t indices1;
-        indices1.push_back(index_info("ATCACGAC-AAGGTTCA", "1", "TSCAIndexes", 4570));
-        expected_metrics.push_back(metric_type(1, 12106, 3, indices1));
-        index_metric::index_array_t indices2;
-        indices2.push_back(index_info("ACAGTGGT-AAGGTTCA", "2", "TSCAIndexes", 4477));
-        expected_metrics.push_back(metric_type(2, 12106, 3, indices2));
-        index_metric::index_array_t indices3;
-        indices3.push_back(index_info("CAGATCCA-AAGGTTCA", "3", "TSCAIndexes", 4578));
-        expected_metrics.push_back(metric_type(3, 12106, 3, indices3));
-        int tmp[] = {1
-                ,1,0,74,47,3,0
-                ,17,0,65,84,67,65,67,71,65,67,45,65,65,71,71,84,84,67,65,218,17,0,0,1,0,49,11,0,84,83,67,65,73,110
-                ,100,101,120,101,115
-                ,2,0,74,47,3,0 // changed to lane 2
-                ,17,0,65,67,65,71,84,71,71,84,45,65,65,71,71,84,84,67,65,125,17,0,0,1,0,50,11,0,84,83,67,65,73,110
-                ,100,101,120,101,115
-                ,3,0,74,47,3,0 // changed to lane 3
-                ,17,0,67,65,71,65,84,67,67,65,45,65,65,71,71,84,84,67,65,226,17,0,0,1,0,51,11,0,84,83,67,65,73,110
-                ,100,101,120,101,115
-        };
-        setup_hardcoded_binary(tmp, header_type());
-    }
-};
-
-
-/** This test writes three records of an InterOp files, then reads them back in and compares
- * each value to ensure they did not change.
- *
- * @note Version 1
- */
-struct index_metrics_write_read_fixture_v1 : util::fixture_helper<index_metrics, 1>
-{
-    enum{
-        /** Do not check record size (does not have it)*/
-        disable_check_record_size=true
-    };
-    /** Setup fixture */
-    index_metrics_write_read_fixture_v1()
-    {
-        index_metric::index_array_t indices1;
-        indices1.push_back(index_info("ATCACGAC-AAGGTTCA", "1", "TSCAIndexes", 4570));
-        expected_metrics.push_back(metric_type(1, 12106, 3, indices1));
-        index_metric::index_array_t indices2;
-        indices2.push_back(index_info("ACAGTGGT-AAGGTTCA", "2", "TSCAIndexes", 4477));
-        expected_metrics.push_back(metric_type(2, 12106, 3, indices2));
-        index_metric::index_array_t indices3;
-        indices3.push_back(index_info("CAGATCCA-AAGGTTCA", "3", "TSCAIndexes", 4578));
-        expected_metrics.push_back(metric_type(3, 12106, 3, indices3));
-        setup_write_read();
-    }
-};
-/** Interface between fixtures and Google Test */
-template<typename TestSetup>
-struct index_metrics_test : public ::testing::Test, public TestSetup { };
-}}}
 using namespace illumina::interop::unittest;
 
-
-
-
 typedef ::testing::Types<
-index_metrics_hardcoded_fixture_v1
-,index_metrics_write_read_fixture_v1
+        hardcoded_fixture<index_v1>,
+        write_read_fixture<index_v1>
 > Formats;
 TYPED_TEST_CASE(index_metrics_test, Formats);
 
@@ -110,10 +28,10 @@ TYPED_TEST_CASE(index_metrics_test, Formats);
 TYPED_TEST(index_metrics_test, test_read_write)
 {
     EXPECT_EQ(TypeParam::actual_metric_set.version(), TypeParam::VERSION);
-    EXPECT_EQ(TypeParam::actual_metrics.size(), TypeParam::expected_metrics.size());
+    EXPECT_EQ(TypeParam::actual_metric_set.size(), TypeParam::expected_metric_set.size());
 
-    for(typename TypeParam::const_iterator itExpected=TypeParam::expected_metrics.begin(), itActual = TypeParam::actual_metrics.begin();
-        itExpected != TypeParam::expected_metrics.end() && itActual != TypeParam::actual_metrics.end();
+    for(typename TypeParam::const_iterator itExpected=TypeParam::expected_metric_set.begin(), itActual = TypeParam::actual_metric_set.begin();
+        itExpected != TypeParam::expected_metric_set.end() && itActual != TypeParam::actual_metric_set.end();
         itExpected++,itActual++)
     {
         EXPECT_EQ(itExpected->lane(), itActual->lane());
@@ -140,6 +58,6 @@ TYPED_TEST(index_metrics_test, test_read_write)
  * @test Confirm file_not_found_exception is thrown when a file is not found
  * @test Confirm reading from good data does not throw an exception
  */
-#include "src/tests/interop/metrics/stream_exception_tests.hpp"
+#include "inc/stream_tests.hpp"
 
 

--- a/src/tests/interop/metrics/q_metrics_test.cpp
+++ b/src/tests/interop/metrics/q_metrics_test.cpp
@@ -11,276 +11,22 @@
 #include <limits>
 #include <fstream>
 #include <gtest/gtest.h>
-#include "interop/model/metric_sets/q_metric_set.h"
-#include "src/tests/interop/metrics/metric_test_utils.h"
+#include "interop/logic/metric/q_metric.h"
+#include "inc/q_metrics_test.h"
 using namespace illumina::interop::model::metrics;
+using namespace illumina::interop::model::metric_base;
 using namespace illumina::interop::io;
-
-
-namespace illumina{ namespace interop { namespace unittest {
-/** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
- * to the values displayed in SAV.
- *
- * Regression set: 1947950_117213Bin2R0I
- *
- * @note Version 4
- */
-struct q_metrics_hardcoded_fixture_v4 : util::fixture_helper<q_metrics, 4>
-{
-    /** Setup fixture */
-    q_metrics_hardcoded_fixture_v4()
-    {
-        typedef metric_type::uint_t uint_t;
-        typedef sparse_value<uint_t, q_metrics::MAX_Q_BINS> q_val;
-        typedef header_type::qscore_bin_vector_type qscore_bin_vector_type;
-
-        qscore_bin_vector_type headervec;
-        header_type header(headervec);
-
-        q_val hist1[] = {q_val(14,21208), q_val(21,8227), q_val(26,73051), q_val(32,2339486)};
-        q_val hist2[] = {q_val(14,22647), q_val(21,9570), q_val(26,81839), q_val(32,2413227)};
-        q_val hist3[] = {q_val(14,18878), q_val(21,8168), q_val(26,72634), q_val(32,2342292)};
-        //std::vector<uint_t> hist_tmp(50, 0);
-
-        expected_metrics.push_back(metric_type(1, 1104, 1, to_vector(hist1)));
-        expected_metrics.push_back(metric_type(1, 1106, 1, to_vector(hist2)));
-        expected_metrics.push_back(metric_type(1, 1104, 2, to_vector(hist3)));
-
-        int tmp[] = {
-                4,206,
-                1,0,80,4,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,216,82,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,35,32,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,91
-                ,29,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,158,178,35,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-                1,0,82,4,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,119,88,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,98,37,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,175,63,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,171,210,36,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-                1,0,80,4,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,190,73,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,232,31,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,186,27,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,148,189,35,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0
-        };
-        setup_hardcoded_binary(tmp, header);
-    }
-};
-
-/** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
- * to the values displayed in SAV.
- *
- * Regression set: 8612619_11864Bin1R2I
- *
- * @note Version 5
- */
-struct q_metrics_hardcoded_fixture_v5 : util::fixture_helper<q_metrics, 5>
-{
-    /** Setup fixture */
-    q_metrics_hardcoded_fixture_v5()
-    {
-        typedef q_score_bin::bin_type ushort_t;
-        typedef metric_type::uint_t uint_t;
-        typedef sparse_value<uint_t, 7> q_val;
-        typedef header_type::qscore_bin_vector_type qscore_bin_vector_type;
-        const uint_t bin_count = 7;
-
-        ushort_t lower[] = {1, 10, 20, 25, 30, 35, 40};
-        ushort_t upper[] = {9, 19, 24, 29, 34, 39, 41};
-        ushort_t value[] = {1, 14, 22, 27, 33, 37, 40};
-        qscore_bin_vector_type headervec;
-        for(uint_t i=0;i<bin_count;i++)
-            headervec.push_back(q_score_bin(lower[i], upper[i], value[i]));
-        header_type header(headervec);
-
-        q_val hist1[] = {q_val(1,45272), q_val(3,33369), q_val(4,1784241)};
-        q_val hist2[] = {q_val(1,45229), q_val(3,34304), q_val(4,1792186)};
-        q_val hist3[] = {q_val(1,49152), q_val(3,37440), q_val(4,1806479)};
-
-        expected_metrics.push_back(metric_type(1, 1103, 1, to_vector(hist1)));
-        expected_metrics.push_back(metric_type(1, 1104, 1, to_vector(hist2)));
-        expected_metrics.push_back(metric_type(1, 1108, 1, to_vector(hist3)));
-
-        int tmp[] = {
-                5,206,
-                1,7,
-                1,10,20,25,30,35,40,9,19,24,29,34,39,41,1,14,22,27,33,37,40,
-                1,0,79,4,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,216,176,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,0,89,130,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,177,57,27,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,0,
-                1,0,80,4,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,173,176,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,0,0,134,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,186,88,27,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,
-                1,0,84,4,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,192,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,0,0,64,146,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,143,144,27,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-                ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-        };
-        setup_hardcoded_binary(tmp, header);
-    }
-};
-
-/** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
- * to the values displayed in SAV.
- *
- * @note Version 6
- */
-struct q_metrics_hardcoded_fixture_v6 : util::fixture_helper<q_metrics, 6>
-{
-    /** Setup fixture */
-    q_metrics_hardcoded_fixture_v6()
-    {
-        typedef q_score_bin::bin_type ushort_t;
-        typedef metric_type::uint_t uint_t;
-        typedef header_type::qscore_bin_vector_type qscore_bin_vector_type;
-        const uint_t bin_count = 7;
-
-        ushort_t lower[] = {2, 10, 20, 25, 30, 35, 40};
-        ushort_t upper[] = {9, 19, 24, 29, 34, 39, 40};
-        ushort_t value[] = {2, 14, 21, 27, 32, 36, 40};
-        qscore_bin_vector_type headervec;
-        for(uint_t i=0;i<bin_count;i++)
-            headervec.push_back(q_score_bin(lower[i], upper[i], value[i]));
-        header_type header(headervec);
-
-        uint_t hist_all1[] = {0, 267962, 118703, 4284, 2796110, 0, 0};
-        uint_t hist_all2[] = {0,241483, 44960, 1100, 2899568, 0 ,0};
-        uint_t hist_all3[] = {0,212144, 53942, 427, 2920598, 0, 0};
-        std::vector<uint_t> hist_tmp(50, 0);
-
-        expected_metrics.push_back(metric_type(7, 1114, 1, to_vector(hist_all1)));
-        expected_metrics.push_back(metric_type(7, 1114, 2, to_vector(hist_all2)));
-        expected_metrics.push_back(metric_type(7, 1114, 3,to_vector(hist_all3)));
-
-        int tmp[] = {
-                6,34,1,7,2,10,20,25,30,35,40,9,19,24,29,34,39,40,2,14,21,27,32,36,40
-                ,7,0,90,4,1,0,0,0,0,0,-70,22,4,0,-81,-49,1,0,-68,16,0,0,78,-86,42,0,0,0,0,0,0,0,0,0
-                ,7,0,90,4,2,0,0,0,0,0,75,-81,3,0,-96,-81,0,0,76,4,0,0,112,62,44,0,0,0,0,0,0,0,0,0
-                ,7,0,90,4,3,0,0,0,0,0,-80,60,3,0,-74,-46,0,0,-85,1,0,0,-106,-112,44,0,0,0,0,0,0,0,0,0
-        };
-        setup_hardcoded_binary(tmp, header);
-    }
-};
-
-/** This test writes three records of an InterOp files, then reads them back in and compares
- * each value to ensure they did not change.
- *
- * @note Version 4
- */
-struct q_metrics_write_read_fixture_v4 : util::fixture_helper<q_metrics, 4>
-{
-    /** Setup fixture */
-    q_metrics_write_read_fixture_v4()
-    {
-        typedef metric_type::uint_t uint_t;
-        typedef sparse_value<uint_t, q_metrics::MAX_Q_BINS> q_val;
-        typedef header_type::qscore_bin_vector_type qscore_bin_vector_type;
-
-        qscore_bin_vector_type headervec;
-        header_type header(headervec);
-
-        q_val hist1[] = {q_val(14,21208), q_val(21,8227), q_val(26,73051), q_val(32,2339486)};
-        q_val hist2[] = {q_val(14,22647), q_val(21,9570), q_val(26,81839), q_val(32,2413227)};
-        q_val hist3[] = {q_val(14,18878), q_val(21,8168), q_val(26,72634), q_val(32,2342292)};
-        //std::vector<uint_t> hist_tmp(50, 0);
-
-        expected_metrics.push_back(metric_type(1, 1104, 1, to_vector(hist1)));
-        expected_metrics.push_back(metric_type(1, 1106, 1, to_vector(hist2)));
-        expected_metrics.push_back(metric_type(1, 1104, 2, to_vector(hist3)));
-
-        setup_write_read(header);
-    }
-};
-
-/** This test writes three records of an InterOp files, then reads them back in and compares
- * each value to ensure they did not change.
- *
- * @note Version 5
- */
-struct q_metrics_write_read_fixture_v5 : util::fixture_helper<q_metrics, 5>
-{
-    /** Setup fixture */
-    q_metrics_write_read_fixture_v5()
-    {
-        typedef q_score_bin::bin_type ushort_t;
-        typedef metric_type::uint_t uint_t;
-        typedef sparse_value<uint_t, 7> q_val;
-        typedef header_type::qscore_bin_vector_type qscore_bin_vector_type;
-        const uint_t bin_count = 7;
-
-        ushort_t lower[] = {1, 10, 20, 25, 30, 35, 40};
-        ushort_t upper[] = {9, 19, 24, 29, 34, 39, 41};
-        ushort_t value[] = {1, 14, 22, 27, 33, 37, 40};
-        qscore_bin_vector_type headervec;
-        for(uint_t i=0;i<bin_count;i++)
-            headervec.push_back(q_score_bin(lower[i], upper[i], value[i]));
-        header_type header(headervec);
-
-        q_val hist1[] = {q_val(1,45272), q_val(3,33369), q_val(4,1784241)};
-        q_val hist2[] = {q_val(1,45229), q_val(3,34304), q_val(4,1792186)};
-        q_val hist3[] = {q_val(1,49152), q_val(3,37440), q_val(4,1806479)};
-
-        expected_metrics.push_back(metric_type(1, 1103, 1, to_vector(hist1)));
-        expected_metrics.push_back(metric_type(1, 1104, 1, to_vector(hist2)));
-        expected_metrics.push_back(metric_type(1, 1108, 1, to_vector(hist3)));
-
-        setup_write_read(header);
-    }
-};
-/** This test writes three records of an InterOp files, then reads them back in and compares
- * each value to ensure they did not change.
- *
- * @note Version 6
- */
-struct q_metrics_write_read_fixture_v6 : util::fixture_helper<q_metrics, 6>
-{
-    /** Setup fixture */
-    q_metrics_write_read_fixture_v6()
-    {
-        typedef q_score_bin::bin_type ushort_t;
-        typedef metric_type::uint_t uint_t;
-        typedef header_type::qscore_bin_vector_type qscore_bin_vector_type;
-        const uint_t bin_count = 7;
-
-        ushort_t lower[] = {2, 10, 20, 25, 30, 35, 40};
-        ushort_t upper[] = {9, 19, 24, 29, 34, 39, 40};
-        ushort_t value[] = {2, 14, 21, 27, 32, 36, 40};
-        qscore_bin_vector_type headervec;
-        for(uint_t i=0;i<bin_count;i++)
-            headervec.push_back(q_score_bin(lower[i], upper[i], value[i]));
-        header_type header(headervec);
-
-        uint_t hist_all1[] = {0, 267962, 118703, 4284, 2796110, 0, 0};
-        uint_t hist_all2[] = {0,241483, 44960, 1100, 2899568, 0 ,0};
-        uint_t hist_all3[] = {0,212144, 53942, 427, 2920598, 0, 0};
-
-        expected_metrics.push_back(metric_type(7, 1114, 1, to_vector(hist_all1)));
-        expected_metrics.push_back(metric_type(7, 1114, 2, to_vector(hist_all2)));
-        expected_metrics.push_back(metric_type(7, 1114, 3, to_vector(hist_all3)));
-
-        setup_write_read(header);
-    }
-};
-/** Interface between fixtures and Google Test */
-template<typename TestSetup>
-struct q_metrics_test : public ::testing::Test, public TestSetup { };
-}}}
-
+using namespace illumina::interop;
 using namespace illumina::interop::unittest;
 
 
 typedef ::testing::Types<
-q_metrics_hardcoded_fixture_v4,
-q_metrics_hardcoded_fixture_v5,
-q_metrics_hardcoded_fixture_v6,
-q_metrics_write_read_fixture_v4,
-q_metrics_write_read_fixture_v5,
-q_metrics_write_read_fixture_v6
+        hardcoded_fixture<q_v4>,
+        write_read_fixture<q_v4>,
+        hardcoded_fixture<q_v5>,
+        write_read_fixture<q_v5>,
+        hardcoded_fixture<q_v6>,
+        write_read_fixture<q_v6>
 > Formats;
 TYPED_TEST_CASE(q_metrics_test, Formats);
 
@@ -296,11 +42,11 @@ TYPED_TEST_CASE(q_metrics_test, Formats);
 TYPED_TEST(q_metrics_test, test_read_write)
 {
     EXPECT_EQ(TypeParam::actual_metric_set.version(), TypeParam::VERSION);
-    EXPECT_EQ(TypeParam::actual_metrics.size(), TypeParam::expected_metrics.size());
+    EXPECT_EQ(TypeParam::actual_metric_set.size(), TypeParam::expected_metric_set.size());
     EXPECT_EQ(TypeParam::actual_metric_set.max_cycle(), TypeParam::expected_metric_set.max_cycle());
 
-    for(typename TypeParam::const_iterator itExpected=TypeParam::expected_metrics.begin(), itActual = TypeParam::actual_metrics.begin();
-        itExpected != TypeParam::expected_metrics.end() && itActual != TypeParam::actual_metrics.end();
+    for(typename TypeParam::const_iterator itExpected=TypeParam::expected_metric_set.begin(), itActual = TypeParam::actual_metric_set.begin();
+        itExpected != TypeParam::expected_metric_set.end() && itActual != TypeParam::actual_metric_set.end();
         itExpected++,itActual++)
     {
         EXPECT_EQ(itExpected->lane(), itActual->lane());
@@ -312,7 +58,7 @@ TYPED_TEST(q_metrics_test, test_read_write)
             EXPECT_EQ(itExpected->qscoreHist(i), itActual->qscoreHist(i));
         }
     }
-    EXPECT_EQ(TypeParam::actual_metric_set.histBinCount(), TypeParam::expected_metric_set.histBinCount());
+    EXPECT_EQ(logic::metric::count_q_metric_bins(TypeParam::actual_metric_set),logic::metric::count_q_metric_bins(TypeParam::expected_metric_set));
     EXPECT_EQ(TypeParam::actual_metric_set.binCount(), TypeParam::expected_metric_set.binCount());
     for(size_t i=0;i<std::min(TypeParam::actual_metric_set.binCount(), TypeParam::expected_metric_set.binCount());i++)
     {
@@ -321,29 +67,30 @@ TYPED_TEST(q_metrics_test, test_read_write)
         EXPECT_EQ(TypeParam::actual_metric_set.binAt(i).value(), TypeParam::expected_metric_set.binAt(i).value());
     }
 }
+
 /**
  * @class illumina::interop::model::metrics::q_metrics
  * @test Confirm populate does not crash on empty q-metrics
  */
 TYPED_TEST(q_metrics_test, test_populate_cumulative_on_empty)
 {
-    TypeParam::actual_metric_set.populateCumulativeDistributions();
+    logic::metric::populate_cumulative_distribution(TypeParam::actual_metric_set);
     for(typename TypeParam::const_iterator cur=TypeParam::actual_metric_set.metrics().begin();cur != TypeParam::actual_metric_set.metrics().end();++cur)
         EXPECT_TRUE(!cur->is_cumulative_empty());
-    q_metrics empty_metrics;
-    empty_metrics.populateCumulativeDistributions();
+    metric_set<q_metric> empty_metrics;
+    logic::metric::populate_cumulative_distribution(empty_metrics);
 }
 
 TEST(q_metrics_test, test_cumulative)
 {
     typedef q_metric::uint_t uint_t;
-    typedef util::fixture_helper<q_metrics, 0> helper_t;
+    typedef metric_test<q_metric, 0> helper_t;
 
     uint_t qsum = 0;
     uint_t hist_all0[] = {0, 267963, 118702, 4281, 2796111, 0, 0};
     uint_t hist_all1[] = {0, 267962, 118703, 4284, 2796110, 0, 0};
-    uint_t hist_all2[] = {0,241483, 44960, 1100, 2899568, 0 ,0};
-    uint_t hist_all3[] = {0,212144, 53942, 427, 2920598, 0, 0};
+    uint_t hist_all2[] = {0, 241483, 44960, 1100, 2899568, 0 ,0};
+    uint_t hist_all3[] = {0, 212144, 53942, 427, 2920598, 0, 0};
 
     std::vector<q_metric> q_metric_vec;
     q_metric_vec.push_back(q_metric(7, 1114, 1, helper_t::to_vector(hist_all1)));
@@ -351,10 +98,10 @@ TEST(q_metrics_test, test_cumulative)
     q_metric_vec.push_back(q_metric(6, 1114, 1, helper_t::to_vector(hist_all0)));
     q_metric_vec.push_back(q_metric(7, 1114, 3, helper_t::to_vector(hist_all3)));
 
-    q_metrics q_metric_set(q_metric_vec, 6, q_metric::header_type());
-    q_metric_set.populateCumulativeDistributions();
+    metric_set<q_metric> q_metric_set(q_metric_vec, 6, q_metric::header_type());
+    logic::metric::populate_cumulative_distribution(q_metric_set);
 
-    for(uint_t i=0;i<helper_t::to_vector(hist_all1).size();i++)
+    for(uint_t i=0;i<helper_t::size_of(hist_all1);i++)
     {
         qsum += hist_all1[i];
         qsum += hist_all2[i];
@@ -375,6 +122,6 @@ TEST(q_metrics_test, test_cumulative)
  * @test Confirm file_not_found_exception is thrown when a file is not found
  * @test Confirm reading from good data does not throw an exception
  */
-#include "src/tests/interop/metrics/stream_exception_tests.hpp"
+#include "inc/stream_tests.hpp"
 
 

--- a/src/tests/interop/metrics/tile_metrics_test.cpp
+++ b/src/tests/interop/metrics/tile_metrics_test.cpp
@@ -10,125 +10,21 @@
 #include <fstream>
 #include <set>
 #include <gtest/gtest.h>
-#include "interop/model/metric_sets/tile_metric_set.h"
-#include "src/tests/interop/metrics/metric_test_utils.h"
+#include "inc/tile_metrics_test.h"
 #include "interop/util/statistics.h"
+#include "interop/util/type_traits.h"
 using namespace illumina::interop::model::metrics;
+using namespace illumina::interop::model::metric_base;
 using namespace illumina::interop::io;
-
-
-namespace illumina{ namespace interop { namespace unittest {
-/** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
- * to the values displayed in SAV.
- *
- * @note Version 2
- */
-struct tile_metrics_hardcoded_fixture_v2 : util::fixture_helper<tile_metrics, 2>
-{
-    enum{
-        /** Do not check the expected binary data */
-        disable_binary_data=true,
-        /** Do not check the expected binary data size */
-        disable_binary_data_size=true
-    };
-    /** Do not scale the phasing
-     *
-     * @return 1
-     */
-    float scale_phasing(){return 1;}
-    /** Setup fixture */
-    tile_metrics_hardcoded_fixture_v2()
-    {
-        metric_type::read_metric_vector reads1;
-        reads1.push_back(metric_type::read_metric_type(1, 2.61630869f, 0.0797112584f, 0.119908921f));
-        reads1.push_back(metric_type::read_metric_type(2, 2.61630869f, 0.0797112584f, 0.119908921f));
-
-        expected_metrics.push_back(metric_type(7, 1114, 2355119.25f,1158081.50f,6470949,3181956,reads1));
-        expected_metrics.push_back(metric_type(7, 1214, 2355119.25f,1174757.75f,6470949,3227776,
-                                               metric_type::read_metric_vector(1, metric_type::read_metric_type(1, 2.62243795f, 0.129267812f, 0.135128692f))));
-        expected_metrics.push_back(metric_type(7, 2114, 2355119.25f,1211592.38f,6470949,3328983,
-                                               metric_type::read_metric_vector(1, metric_type::read_metric_type(1, 2.490309f, 0.11908555f, 0.092706576f))));
-        int tmp[] = {
-                2,10
-                ,7,0,90,4,100,0,-67,-66,15,74
-                ,7,0,90,4,102,0,74,122,-59,74
-                ,7,0,90,4,101,0,12,94,-115,73
-                ,7,0,90,4,103,0,16,54,66,74
-                ,7,0,90,4,-56,0,82,-11,80,58
-                ,7,0,90,4,-55,0,-62,42,-99,58
-                ,7,0,90,4,44,1,-102,113,39,64
-                ,7,0,90,4,-54,0,82,-11,80,58
-                ,7,0,90,4,-53,0,-62,42,-99,58
-                ,7,0,90,4,45,1,-102,113,39,64
-                ,7,0,90,4,-56,0,82,-11,80,58
-                ,7,0,90,4,-55,0,-62,42,-99,58
-                ,7,0,90,4,44,1,-102,113,39,64
-                ,7,0,-66,4,100,0,-67,-66,15,74
-                ,7,0,-66,4,102,0,74,122,-59,74
-                ,7,0,-66,4,101,0,46,103,-113,73
-                ,7,0,-66,4,103,0,0,2,69,74
-                ,7,0,-66,4,-56,0,21,111,-87,58
-                ,7,0,-66,4,-55,0,-86,29,-79,58
-                ,7,0,-66,4,44,1,6,-42,39,64
-                ,7,0,66,8,100,0,-67,-66,15,74
-                ,7,0,66,8,102,0,74,122,-59,74
-                ,7,0,66,8,101,0,67,-26,-109,73
-                ,7,0,66,8,103,0,92,47,75,74
-                ,7,0,66,8,-56,0,123,22,-100,58
-                ,7,0,66,8,-55,0,85,6,115,58
-                ,7,0,66,8,44,1,57,97,31,64
-                ,7,0,66,8,144,1,0,0,0,0   // Test whether control lane accidentally clears data
-                ,6,0,66,8,144,1,0,0,0,0   // Test whether control lane for empty tile shows up
-        };
-        setup_hardcoded_binary(tmp, header_type());
-    }
-};
-
-
-/** This test writes three records of an InterOp files, then reads them back in and compares
- * each value to ensure they did not change.
- *
- * @note Version 2
- */
-struct tile_metrics_write_read_fixture_v2 : util::fixture_helper<tile_metrics, 2>
-{
-    enum{
-        /** Do not check the expected binary data */
-        disable_binary_data=true
-    };
-
-    /** Scale the phasing
-     *
-     * @return 100
-     */
-    float scale_phasing(){return 100;}
-    /** Setup fixture */
-    tile_metrics_write_read_fixture_v2()
-    {
-        metric_type::read_metric_vector reads1;
-        reads1.push_back(metric_type::read_metric_type(1, 2.61630869f, 0.0797112584f, 0.119908921f));
-        reads1.push_back(metric_type::read_metric_type(2, 2.61630869f, 0.0797112584f, 0.119908921f));
-
-        expected_metrics.push_back(metric_type(7, 1114, 2355119.25f,1158081.50f,6470949,3181956,reads1));
-        expected_metrics.push_back(metric_type(7, 1214, 2355119.25f,1174757.75f,6470949,3227776,
-                                               metric_type::read_metric_vector(1, metric_type::read_metric_type(1, 2.62243795f, 0.129267812f, 0.135128692f))));
-        expected_metrics.push_back(metric_type(7, 2114, 2355119.25f,1211592.38f,6470949,3328983,
-                                               metric_type::read_metric_vector(1, metric_type::read_metric_type(1, 2.490309f, 0.11908555f, 0.092706576f))));
-        setup_write_read();
-    }
-};
-/** Interface between fixtures and Google Test */
-template<typename TestSetup>
-struct tile_metrics_test : public ::testing::Test, public TestSetup { };
-}}}
+using namespace illumina::interop;
 using namespace illumina::interop::unittest;
 using namespace illumina;
 
 
 
 typedef ::testing::Types<
-tile_metrics_hardcoded_fixture_v2,
-tile_metrics_write_read_fixture_v2
+        hardcoded_fixture<tile_v2>,
+        write_read_fixture<tile_v2>
 > Formats;
 TYPED_TEST_CASE(tile_metrics_test, Formats);
 
@@ -139,12 +35,13 @@ TYPED_TEST_CASE(tile_metrics_test, Formats);
  */
 TYPED_TEST(tile_metrics_test, test_read_write)
 {
+    const float scale = is_same< TypeParam, write_read_fixture<tile_v2> >::value ? 100 : 1;
     EXPECT_EQ(TypeParam::actual_metric_set.version(), TypeParam::VERSION);
-    EXPECT_EQ(TypeParam::actual_metrics.size(), TypeParam::expected_metrics.size());
+    EXPECT_EQ(TypeParam::actual_metric_set.size(), TypeParam::expected_metric_set.size());
 
     const float tol = 1e-7f / 0.01f;
-    for(typename TypeParam::const_iterator itExpected=TypeParam::expected_metrics.begin(), itActual = TypeParam::actual_metrics.begin();
-        itExpected != TypeParam::expected_metrics.end() && itActual != TypeParam::actual_metrics.end();
+    for(typename TypeParam::const_iterator itExpected=TypeParam::expected_metric_set.begin(), itActual = TypeParam::actual_metric_set.begin();
+        itExpected != TypeParam::expected_metric_set.end() && itActual != TypeParam::actual_metric_set.end();
         itExpected++,itActual++)
     {
         EXPECT_EQ(itExpected->lane(), itActual->lane());
@@ -155,25 +52,35 @@ TYPED_TEST(tile_metrics_test, test_read_write)
         EXPECT_NEAR(itExpected->clusterCount(), itActual->clusterCount(), tol);
         EXPECT_NEAR(itExpected->clusterCountPf(), itActual->clusterCountPf(), tol);
         EXPECT_EQ(itExpected->read_metrics().size(), itActual->read_metrics().size());
-        for(typename TypeParam::metric_type::read_metric_vector::const_iterator itReadExpected = itExpected->read_metrics().begin(),
+        for(typename TypeParam::metric_t::read_metric_vector::const_iterator itReadExpected = itExpected->read_metrics().begin(),
                         itReadActual = itActual->read_metrics().begin();
                         itReadExpected != itExpected->read_metrics().end() &&
                         itReadActual != itActual->read_metrics().end(); itReadExpected++, itReadActual++)
         {
             EXPECT_EQ(itReadExpected->read(), itReadActual->read());
             EXPECT_NEAR(itReadExpected->percent_aligned(), itReadActual->percent_aligned(), tol);
-            EXPECT_NEAR(itReadExpected->percent_phasing()*TypeParam::scale_phasing(), itReadActual->percent_phasing(), tol);
-            EXPECT_NEAR(itReadExpected->percent_prephasing()*TypeParam::scale_phasing(), itReadActual->percent_prephasing(), tol);
+            EXPECT_NEAR(itReadExpected->percent_phasing()*scale, itReadActual->percent_phasing(), tol);
+            EXPECT_NEAR(itReadExpected->percent_prephasing()*scale, itReadActual->percent_prephasing(), tol);
         }
     }
+}
+
+TYPED_TEST(tile_metrics_test, median)
+{
+    const float tol = 1e-7f / 0.01f;
+    const size_t read = 0;
+    float expected_percent_aligned_avg = interop::util::median(TypeParam::expected_metric_set.begin(),
+                                                                    TypeParam::expected_metric_set.end(),
+                                                                    interop::util::op::const_member_function_less(read, &tile_metric::percent_aligned))->percent_aligned(read);
+    EXPECT_NEAR(expected_percent_aligned_avg, 2.6163086891174316, tol);
 }
 
 TYPED_TEST(tile_metrics_test, mean)
 {
     const float tol = 1e-7f / 0.01f;
     const size_t read = 0;
-    float expected_percent_aligned_avg = interop::util::mean<float>(TypeParam::expected_metrics.begin(),
-                                                                    TypeParam::expected_metrics.end(),
+    float expected_percent_aligned_avg = interop::util::mean<float>(TypeParam::expected_metric_set.begin(),
+                                                                    TypeParam::expected_metric_set.end(),
                                                                     interop::util::op::const_member_function(read, &tile_metric::percent_aligned));
     EXPECT_NEAR(expected_percent_aligned_avg, 2.5763518810272217, tol);
 }
@@ -182,8 +89,8 @@ TYPED_TEST(tile_metrics_test, nan_mean)
 {
     const float tol = 1e-7f / 0.01f;
     const size_t read = 0;
-    float expected_percent_aligned_avg = interop::util::nan_mean<float>(TypeParam::expected_metrics.begin(),
-                                                                        TypeParam::expected_metrics.end(),
+    float expected_percent_aligned_avg = interop::util::nan_mean<float>(TypeParam::expected_metric_set.begin(),
+                                                                        TypeParam::expected_metric_set.end(),
                                                                         interop::util::op::const_member_function(read, &tile_metric::percent_aligned));
     EXPECT_NEAR(expected_percent_aligned_avg, 2.5763518810272217, tol);
 }
@@ -193,8 +100,8 @@ TYPED_TEST(tile_metrics_test, standard_deviation)
 {
     const float tol = 1e-7f / 0.01f;
     const size_t read = 0;
-    float expected_percent_aligned_std = std::sqrt(interop::util::variance<float>(TypeParam::expected_metrics.begin(),
-                                                                                  TypeParam::expected_metrics.end(),
+    float expected_percent_aligned_std = std::sqrt(interop::util::variance<float>(TypeParam::expected_metric_set.begin(),
+                                                                                  TypeParam::expected_metric_set.end(),
                                                                                   interop::util::op::const_member_function(read, &tile_metric::percent_aligned)));
     EXPECT_NEAR(expected_percent_aligned_std, 0.074578315019607544, tol);
 }
@@ -203,8 +110,8 @@ TYPED_TEST(tile_metrics_test, nan_standard_deviation)
 {
     const float tol = 1e-7f / 0.01f;
     const size_t read = 0;
-    float expected_percent_aligned_std = std::sqrt(interop::util::nan_variance<float>(TypeParam::expected_metrics.begin(),
-                                                                                  TypeParam::expected_metrics.end(),
+    float expected_percent_aligned_std = std::sqrt(interop::util::nan_variance<float>(TypeParam::expected_metric_set.begin(),
+                                                                                  TypeParam::expected_metric_set.end(),
                                                                                   interop::util::op::const_member_function(read, &tile_metric::percent_aligned)));
     EXPECT_NEAR(expected_percent_aligned_std, 0.074578315019607544, tol);
 }
@@ -213,8 +120,8 @@ TYPED_TEST(tile_metrics_test, standard_deviation_vec)
 {
     const float tol = 1e-7f / 0.01f;
     const size_t read = 0;
-    std::vector<float> percent_aligned_vec(TypeParam::expected_metrics.size());
-    for(size_t i=0;i<TypeParam::expected_metrics.size();++i) percent_aligned_vec[i] = TypeParam::expected_metrics[i].percent_aligned(read);
+    std::vector<float> percent_aligned_vec(TypeParam::expected_metric_set.size());
+    for(size_t i=0;i<TypeParam::expected_metric_set.size();++i) percent_aligned_vec[i] = TypeParam::expected_metric_set.at(i).percent_aligned(read);
     float expected_percent_aligned_std = std::sqrt(interop::util::variance<float>(percent_aligned_vec.begin(),
                                                                                   percent_aligned_vec.end()));
     EXPECT_NEAR(expected_percent_aligned_std, 0.074578315019607544, tol);
@@ -222,10 +129,10 @@ TYPED_TEST(tile_metrics_test, standard_deviation_vec)
 
 TEST(tile_metrics_test, test_unique_id_four_digit)
 {
-    typedef tile_metrics::uint_t uint_t;
-    typedef tile_metrics::id_t id_t;
+    typedef metric_set<tile_metric>::uint_t uint_t;
+    typedef metric_set<tile_metric>::id_t id_t;
     std::set<id_t> ids;
-    tile_metrics metrics;
+    metric_set<tile_metric> metrics;
     for(uint_t lane=1;lane<=8;++lane)
     {
         for(uint_t surface=1;surface<=2;++surface) {
@@ -246,10 +153,10 @@ TEST(tile_metrics_test, test_unique_id_four_digit)
 
 TEST(tile_metrics_test, test_unique_id_five_digit)
 {
-    typedef tile_metrics::uint_t uint_t;
-    typedef tile_metrics::id_t id_t;
+    typedef metric_set<tile_metric>::uint_t uint_t;
+    typedef metric_set<tile_metric>::id_t id_t;
     std::set<id_t> ids;
-    tile_metrics metrics;
+    metric_set<tile_metric> metrics;
     for(uint_t lane=1;lane<=8;++lane)
     {
         for(uint_t surface=1;surface<=2;++surface) {
@@ -257,7 +164,7 @@ TEST(tile_metrics_test, test_unique_id_five_digit)
                 for(uint_t section=1;section <=4;++section) {
                     for (uint_t tile = 1; tile <= 36; ++tile) {
                         tile_metric metric(lane, surface * 10000 + swath * 1000 + section*100 + tile, 0, 0, 0, 0);
-                        metrics.insert(metric.id(), metric);
+                        metrics.insert(metric);
                     }
                 }
             }
@@ -272,11 +179,11 @@ TEST(tile_metrics_test, test_unique_id_five_digit)
 
 TEST(tile_metrics_test, test_tile_metric_for_lane)
 {
-    tile_metrics metrics;
+    metric_set<tile_metric> metrics;
     tile_metric expected_metric(7, 1114, 2355119.25f,1158081.50f,6470949,3181956,
                 tile_metric::read_metric_vector(1, tile_metric::read_metric_type(3, 2.61630869f, 0.0797112584f/100, 0.119908921f/100)));
     metrics.insert(expected_metric.id(), expected_metric);
-    tile_metrics::metric_array_t tile_lane_metrics = metrics.metrics_for_lane(7);
+    metric_set<tile_metric>::metric_array_t tile_lane_metrics = metrics.metrics_for_lane(7);
     tile_metric& actual_metric = tile_lane_metrics[0];
 
     EXPECT_EQ(expected_metric.lane(), actual_metric.lane());
@@ -303,5 +210,5 @@ TEST(tile_metrics_test, test_tile_metric_for_lane)
  * @test Confirm file_not_found_exception is thrown when a file is not found
  * @test Confirm reading from good data does not throw an exception
  */
-#include "src/tests/interop/metrics/stream_exception_tests.hpp"
+#include "inc/stream_tests.hpp"
 


### PR DESCRIPTION
This is a refactor of the unit tests to better support summary logic testing