### PR TITLE
IPA-4246: Add search for non Out interop files

### DIFF
--- a/interop/io/format/abstract_metric_format.h
+++ b/interop/io/format/abstract_metric_format.h
@@ -10,7 +10,6 @@
 #pragma once
 #include <istream>
 #include <ostream>
-#include <assert.h>
 #include "interop/util/cstdint.h"
 
 namespace illumina {

--- a/interop/io/format/generic_layout.h
+++ b/interop/io/format/generic_layout.h
@@ -38,6 +38,8 @@ namespace illumina {
                 };
                 /** Define a record size type */
                 typedef ::uint8_t record_size_t;
+                /** Define a version type */
+                typedef ::uint8_t version_t;
 
                 /** Map reading/writing a header to a stream
                  *
@@ -54,6 +56,4 @@ namespace illumina {
         }
     }
 }
-
-
 

--- a/interop/io/format/metric_format_factory.h
+++ b/interop/io/format/metric_format_factory.h
@@ -7,14 +7,14 @@
  *  @copyright GNU Public License.
  */
 #pragma once
-#include <assert.h>
 #include <map>
 #include <vector>
-#include "abstract_metric_format.h"
+#include "interop/util/assert.h"
+#include "interop/io/format/abstract_metric_format.h"
 #include "interop/util/unique_ptr.h"
 #include "interop/util/lexical_cast.h"
 #include "interop/io/stream_exceptions.h"
-#include "metric_format.h"
+#include "interop/io/format/metric_format.h"
 
 /** Register a metric format with the factory
  *
@@ -68,7 +68,7 @@ namespace illumina {
                  */
                 metric_format_factory(abstract_metric_format<Metric>* pformat)
                 {
-                    assert(pformat!=0);
+                   INTEROP_ASSERT(pformat!=0);
                     metric_formats()[pformat->version()]=metric_format_pointer(pformat);
                 }
                 /** Static initialization workaround for member variables

--- a/interop/io/layout/base_metric.h
+++ b/interop/io/layout/base_metric.h
@@ -37,8 +37,6 @@ namespace illumina
                      */
                     struct base_metric
                     {
-                        /** Define an ID type */
-                        typedef ::uint64_t id_t;
                         /** Define a record size type */
                         typedef ::uint8_t record_size_t;
                         /** Constructor
@@ -62,33 +60,6 @@ namespace illumina
                         {
                             lane = static_cast< ::uint16_t >(metric.lane());
                             tile = static_cast< ::uint16_t >(metric.tile());
-                        }
-                        /** Unique id created from both the lane and tile
-                         *
-                         * @return unique id
-                         */
-                        id_t id()const
-                        {
-                            return id(lane, tile);
-                        }
-                        /** Unique id created from both the lane and tile
-                         *
-                         * @param lane lane number
-                         * @param tile tile number
-                         * @return unique id
-                         */
-                        static id_t id(id_t lane, id_t tile)
-                        {
-                            return lane | (tile << 6);
-                        }
-                        /** Get the lane from the unique lane/tile id
-                         *
-                         * @param id unique lane/tile id
-                         * @return lane number
-                         */
-                        static id_t lane_from_id(const id_t id)
-                        {
-                            return id & ~((~0u) << 6);
                         }
                         /** Test if the layout contains valid data
                          *
@@ -133,25 +104,6 @@ namespace illumina
                             base_metric::set(metric);
                             cycle = static_cast< ::uint16_t >(metric.cycle());
                         }
-                        /** Unique id created from the lane, tile and cycle
-                         *
-                         * @return unique id
-                         */
-                        id_t id()const
-                        {
-                            return id(lane, tile, cycle);
-                        }
-                        /** Unique id created from both the lane, tile and cycle
-                         *
-                         * @param lane lane number
-                         * @param tile tile number
-                         * @param cycle cycle number
-                         * @return unique id
-                         */
-                        static id_t id(id_t lane, id_t tile, id_t cycle)
-                        {
-                            return base_metric::id(lane, tile) | (cycle << 32);
-                        }
                         /** Test if the layout contains valid data
                          *
                          * @return true if data is valid
@@ -192,25 +144,6 @@ namespace illumina
                         {
                             base_metric::set(metric);
                             read = static_cast< ::uint16_t >(metric.read());
-                        }
-                        /** Unique id created from the lane, tile and read
-                         *
-                         * @return unique id
-                         */
-                        id_t id()const
-                        {
-                            return id(lane, tile, read);
-                        }
-                        /** Unique id created from both the lane, tile and read
-                         *
-                         * @param lane lane number
-                         * @param tile tile number
-                         * @param read_ read number
-                         * @return unique id
-                         */
-                        static id_t id(id_t lane, id_t tile, id_t read_)
-                        {
-                            return base_metric::id(lane, tile) | (read_ << 32);
                         }
                         /** Test if the layout contains valid data
                          *

--- a/interop/io/metric_stream.h
+++ b/interop/io/metric_stream.h
@@ -90,7 +90,7 @@ namespace illumina {
                     throw bad_format_exception("No format found to parse file with version: " +
                                                util::lexical_cast<std::string>(version) + " of " +
                                                util::lexical_cast<std::string>(format_map.size()));
-                assert(format_map[version]);
+               INTEROP_ASSERT(format_map[version]);
                 metrics.set_version(static_cast< ::int16_t>(version));
                 const std::streamsize record_size = format_map[version]->read_header(in, metrics);
 
@@ -166,7 +166,7 @@ namespace illumina {
                                                util::lexical_cast<std::string>(version) + " of " +
                                                util::lexical_cast<std::string>(format_map.size()));
 
-                assert(format_map[version]);
+               INTEROP_ASSERT(format_map[version]);
                 return format_map[version]->record_size(header);
             }
             /** Get the size of a metric file header
@@ -187,7 +187,7 @@ namespace illumina {
                                                util::lexical_cast<std::string>(version) + " of " +
                                                util::lexical_cast<std::string>(format_map.size()));
 
-                assert(format_map[version]);
+               INTEROP_ASSERT(format_map[version]);
                 return format_map[version]->header_size(header);
             }
             /** Write a metric to a binary InterOp file
@@ -209,7 +209,7 @@ namespace illumina {
                                                util::lexical_cast<std::string>(version) + " of " +
                                                util::lexical_cast<std::string>(format_map.size()));
 
-                assert(format_map[version]);
+               INTEROP_ASSERT(format_map[version]);
                 format_map[version]->write_metric(out, metric, header);
             }
             /** Write a header describing the metric records
@@ -229,7 +229,7 @@ namespace illumina {
                                                util::lexical_cast<std::string>(version) + " of " +
                                                util::lexical_cast<std::string>(format_map.size()));
 
-                assert(format_map[version]);
+               INTEROP_ASSERT(format_map[version]);
                 format_map[version]->write_metric_header(out, header);
             }
             /** Write a metric header to a binary Interop output stream
@@ -252,7 +252,7 @@ namespace illumina {
                                                util::lexical_cast<std::string>(version) + " of " +
                                                util::lexical_cast<std::string>(format_map.size()));
 
-                assert(format_map[version]);
+               INTEROP_ASSERT(format_map[version]);
                 format_map[version]->write_metric_header(out, metrics);
                 for (typename MetricSet::metric_array_t::const_iterator it = metrics.metrics().begin();
                      it != metrics.metrics().end(); it++)

--- a/interop/model/metric_base/base_cycle_metric.h
+++ b/interop/model/metric_base/base_cycle_metric.h
@@ -105,7 +105,7 @@ namespace illumina {
                      */
                     static id_t id(const id_t lane, const id_t tile, const id_t cycle)
                     {
-                        return io::layout::base_cycle_metric::id(lane, tile, cycle);
+                        return base_metric::id(lane, tile) | (cycle << TILE_BIT_SHIFT);
                     }
 
                 private:

--- a/interop/model/metric_base/base_metric.h
+++ b/interop/model/metric_base/base_metric.h
@@ -49,7 +49,6 @@ namespace illumina {
                  */
                 class base_metric
                 {
-                    //typedef layout::base_metric::id_t id_t; // TODO find workaround -> does not compile with SWIG
                 public:
                     /** Unsigned long
                      */
@@ -66,6 +65,13 @@ namespace illumina {
                     /** Base metric header that adds no functionality
                      */
                     typedef base_metric_header header_type;
+                    enum
+                    {
+                        LANE_BIT_COUNT=6, // Supports up to 63 lanes
+                        TILE_BIT_COUNT=32,
+                        LANE_BIT_SHIFT=LANE_BIT_COUNT, // Supports up to 63 lanes
+                        TILE_BIT_SHIFT=LANE_BIT_COUNT+TILE_BIT_COUNT
+                    };
                 public:
                     /** Constructor
                      *
@@ -100,9 +106,9 @@ namespace illumina {
                      * @param tile tile number
                      * @return unique id
                      */
-                    static id_t id(const id_t lane, const id_t tile, const id_t=0)// TODO: remove hack
+                    static id_t id(const id_t lane, const id_t tile, const id_t=0)// TODO: remove hack (const id_t=0)
                     {
-                        return io::layout::base_metric::id(lane, tile);
+                        return lane | (tile << LANE_BIT_SHIFT);
                     }
                     /** Get the lane from the unique lane/tile id
                      *
@@ -111,7 +117,7 @@ namespace illumina {
                      */
                     static id_t lane_from_id(const id_t id)
                     {
-                        return io::layout::base_metric::lane_from_id(id);
+                        return id & ~((~0u) << LANE_BIT_SHIFT);
                     }
                     /** Lane number
                      *

--- a/interop/model/metric_base/base_read_metric.h
+++ b/interop/model/metric_base/base_read_metric.h
@@ -64,7 +64,7 @@ namespace illumina {
                      */
                     static id_t id(const id_t lane, const id_t tile, const id_t read)
                     {
-                        return io::layout::base_read_metric::id(lane, tile, read);
+                        return base_metric::id(lane, tile) | (read << TILE_BIT_SHIFT);
                     }
 
                 private:

--- a/interop/model/metric_base/metric_set.h
+++ b/interop/model/metric_base/metric_set.h
@@ -189,7 +189,7 @@ namespace illumina {
                         typename std::map<id_t, size_t>::const_iterator it = m_id_map.find(key);
                         if(it == m_id_map.end())
                             throw index_out_of_bounds_exception("No tile available: key: "+util::lexical_cast<std::string>(key)+" map: "+util::lexical_cast<std::string>(m_id_map.size())+" == data: "+util::lexical_cast<std::string>(m_data.size()));
-                        assert(it->second < m_data.size());
+                       INTEROP_ASSERT(it->second < m_data.size());
                         return m_data[it->second];
                     }
                     /** Get a metric at the given index

--- a/interop/model/metrics/corrected_intensity_metric.h
+++ b/interop/model/metrics/corrected_intensity_metric.h
@@ -23,7 +23,6 @@
 
 #include <limits>
 #include <numeric>
-#include <assert.h>
 #include <cstring>
 #include <fstream>
 #include "interop/constants/enums.h"
@@ -110,9 +109,9 @@ namespace illumina {
                             m_calledCounts(calledCounts),
                             m_signalToNoise(signalToNoise)
                     {
-                        assert(correctedIntAll.size() == constants::NUM_OF_BASES);
-                        assert(correctedIntCalled.size() == constants::NUM_OF_BASES);
-                        assert(calledCounts.size() == constants::NUM_OF_BASES_AND_NC);
+                       INTEROP_ASSERT(correctedIntAll.size() == constants::NUM_OF_BASES);
+                       INTEROP_ASSERT(correctedIntCalled.size() == constants::NUM_OF_BASES);
+                       INTEROP_ASSERT(calledCounts.size() == constants::NUM_OF_BASES_AND_NC);
                     }
                     /** Constructor
                      *
@@ -141,9 +140,9 @@ namespace illumina {
                             m_calledCounts(calledCounts, calledCounts+constants::NUM_OF_BASES_AND_NC),
                             m_signalToNoise(signalToNoise)
                     {
-                        assert(m_correctedIntAll.size() == constants::NUM_OF_BASES);
-                        assert(m_correctedIntCalled.size() == constants::NUM_OF_BASES);
-                        assert(m_calledCounts.size() == constants::NUM_OF_BASES_AND_NC);
+                       INTEROP_ASSERT(m_correctedIntAll.size() == constants::NUM_OF_BASES);
+                       INTEROP_ASSERT(m_correctedIntCalled.size() == constants::NUM_OF_BASES);
+                       INTEROP_ASSERT(m_calledCounts.size() == constants::NUM_OF_BASES_AND_NC);
                     }
                     /** Constructor
                      *
@@ -166,8 +165,8 @@ namespace illumina {
                             m_calledCounts(calledCounts),
                             m_signalToNoise(std::numeric_limits<float>::quiet_NaN())
                     {
-                        assert(correctedIntCalled.size() == constants::NUM_OF_BASES);
-                        assert(calledCounts.size() == constants::NUM_OF_BASES_AND_NC);
+                       INTEROP_ASSERT(correctedIntCalled.size() == constants::NUM_OF_BASES);
+                       INTEROP_ASSERT(calledCounts.size() == constants::NUM_OF_BASES_AND_NC);
                     }
                     /** Constructor
                      *
@@ -190,8 +189,8 @@ namespace illumina {
                             m_calledCounts(calledCounts, calledCounts+constants::NUM_OF_BASES_AND_NC),
                             m_signalToNoise(std::numeric_limits<float>::quiet_NaN())
                     {// TODO: Add array safety to this constructor
-                        assert(m_correctedIntCalled.size() == constants::NUM_OF_BASES);
-                        assert(m_calledCounts.size() == constants::NUM_OF_BASES_AND_NC);
+                       INTEROP_ASSERT(m_correctedIntCalled.size() == constants::NUM_OF_BASES);
+                       INTEROP_ASSERT(m_calledCounts.size() == constants::NUM_OF_BASES_AND_NC);
                     }
 
                 public:
@@ -220,7 +219,7 @@ namespace illumina {
                      */
                     ushort_t correctedIntAll(size_t index)const
                     {
-                        assert(index < static_cast<size_t>(constants::NUM_OF_BASES));
+                       INTEROP_ASSERT(index < static_cast<size_t>(constants::NUM_OF_BASES));
                         return m_correctedIntAll[index];
                     }
                     /** Average corrected intensity for only base called clusters: A, C, G and T
@@ -231,7 +230,7 @@ namespace illumina {
                      */
                     ushort_t correctedIntCalled(size_t index)const
                     {
-                        assert(index < static_cast<size_t>(constants::NUM_OF_BASES));
+                       INTEROP_ASSERT(index < static_cast<size_t>(constants::NUM_OF_BASES));
                         return m_correctedIntCalled[index];
                     }
                     /** Average corrected intensity for only base called clusters: A, C, G and T
@@ -261,7 +260,7 @@ namespace illumina {
                      */
                     uint_t calledCounts(difference_type index)const
                     {
-                        assert((index+1) < static_cast<difference_type>(constants::NUM_OF_BASES_AND_NC));
+                       INTEROP_ASSERT((index+1) < static_cast<difference_type>(constants::NUM_OF_BASES_AND_NC));
                         return m_calledCounts[static_cast<uint_t>(index+1)];
                     }
                     /** Number of clusters per no call

--- a/interop/model/metrics/error_metric.h
+++ b/interop/model/metrics/error_metric.h
@@ -14,7 +14,6 @@
  *  @copyright GNU Public License.
  */
 #pragma once
-#include <assert.h>
 #include <cstring>
 #include "interop/model/metric_base/base_cycle_metric.h"
 #include "interop/model/metric_base/metric_set.h"
@@ -62,10 +61,10 @@ namespace illumina {
                      * @param cycle cycle number
                      * @param error error rate for current cycle
                      */
-                    error_metric(uint_t lane,
-                                 uint_t tile,
-                                 uint_t cycle,
-                                 float error) :
+                    error_metric(const uint_t lane,
+                                 const uint_t tile,
+                                 const uint_t cycle,
+                                 const float error) :
                             metric_base::base_cycle_metric(lane,tile,cycle),
                             m_errorRate(error),
                             m_mismatch_cluster_count(MAX_MISMATCH, 0)
@@ -103,7 +102,7 @@ namespace illumina {
                      */
                     uint_t mismatch_cluster_count(size_t n)const
                     {
-                        assert(n<MAX_MISMATCH);
+                       INTEROP_ASSERT(n<MAX_MISMATCH);
                         return m_mismatch_cluster_count[n];
                     }
                     /** Size of mismatch array

--- a/interop/model/metrics/extraction_metric.h
+++ b/interop/model/metrics/extraction_metric.h
@@ -13,7 +13,6 @@
  *  @copyright GNU Public License.
  */
 #pragma once
-#include <assert.h>
 #include <ctime>
 #include <cstring>
 #include <algorithm>
@@ -212,8 +211,8 @@ namespace illumina {
                      */
                     ushort_t max_intensity(size_t channel)const
                     {
-                        assert(channel<MAX_CHANNELS);
-                        assert(m_max_intensity_values.size() == MAX_CHANNELS);
+                       INTEROP_ASSERT(channel<MAX_CHANNELS);
+                       INTEROP_ASSERT(m_max_intensity_values.size() == MAX_CHANNELS);
                         return m_max_intensity_values[channel];
                     }
                     /** Median Full Width Half Max (FWHM) Focus Metric
@@ -223,8 +222,8 @@ namespace illumina {
                      */
                     float focusScore(size_t channel)const
                     {
-                        assert(channel <MAX_CHANNELS);
-                        assert(m_focusScores.size()==MAX_CHANNELS);
+                       INTEROP_ASSERT(channel <MAX_CHANNELS);
+                       INTEROP_ASSERT(m_focusScores.size()==MAX_CHANNELS);
                         return m_focusScores[channel];
                     }
                     /** Get an array of maximum intensity values

--- a/interop/model/metrics/image_metric.h
+++ b/interop/model/metrics/image_metric.h
@@ -13,7 +13,6 @@
  *  @copyright GNU Public License.
  */
 #pragma once
-#include <assert.h>
 #include <cstring>
 #include "interop/io/format/generic_layout.h"
 #include "interop/io/layout/base_metric.h"
@@ -156,7 +155,7 @@ namespace illumina {
                      */
                     ushort_t minContrast(size_t channel)const
                     {
-                        assert(channel < m_channelCount);
+                       INTEROP_ASSERT(channel < m_channelCount);
                         return m_minContrast[channel];
                     }
                     /** Maximum contrast intensity
@@ -165,7 +164,7 @@ namespace illumina {
                      */
                     ushort_t maxContrast(size_t channel)const
                     {
-                        assert(channel < m_channelCount);
+                       INTEROP_ASSERT(channel < m_channelCount);
                         return m_maxContrast[channel];
                     }
                     /** Minimum contrast intensity

--- a/interop/model/metrics/index_metric.h
+++ b/interop/model/metrics/index_metric.h
@@ -13,9 +13,9 @@
  *  @copyright GNU Public License.
  */
 #pragma once
-#include <assert.h>
 #include <string>
 #include <map>
+#include "interop/util/assert.h"
 #include "interop/model/metric_base/base_read_metric.h"
 #include "interop/io/format/generic_layout.h"
 
@@ -60,7 +60,7 @@ public:
     index_info(const std::string& index_seq,
                const std::string& sample_id,
                const std::string& sample_proj,
-               size_t count) :
+               const size_t count) :
             m_index_seq(index_seq),
             m_sample_id(sample_id),
             m_sample_proj(sample_proj),
@@ -168,7 +168,7 @@ public:
      */
     const index_info& indices(size_t n)const
     {
-        assert(n<m_indices.size());
+       INTEROP_ASSERT(n<m_indices.size());
         return m_indices[n];
     }
     /** Get an array of indices

--- a/interop/model/metrics/q_metric.h
+++ b/interop/model/metrics/q_metric.h
@@ -12,7 +12,6 @@
  *  @copyright GNU Public License.
  */
 #pragma once
-#include <assert.h>
 #include <cstring>
 #include <numeric>
 #include "interop/model/metric_base/base_cycle_metric.h"
@@ -38,9 +37,25 @@ namespace illumina {
                      * @param upper upper end of the bin range
                      * @param value value of the bin
                      */
-                    q_score_bin(bin_type lower=0, bin_type upper=0, bin_type value=0) : m_lower(lower),
-                                                                                        m_upper(upper),
-                                                                                        m_value(value){}
+                    q_score_bin(const bin_type lower=0, const bin_type upper=0, const bin_type value=0) :
+                            m_lower(lower),
+                            m_upper(upper),
+                            m_value(value){}
+                public:
+                    /** Assign type val to point2d
+                     *
+                     * @param val type that defines m_x and m_y
+                     * @return point2d
+                     */
+                    template<class T>
+                    q_score_bin& operator=(const T& val)
+                    {
+                        m_lower = val.m_lower;
+                        m_upper = val.m_upper;
+                        m_value = val.m_value;
+                        return *this;
+                    }
+
                 public:
                     /** @defgroup q_score_bin Quality Bin
                      *
@@ -110,9 +125,9 @@ namespace illumina {
                      *
                      * @return q-score bin
                      */
-                    const q_score_bin& binAt(size_t n)const
+                    const q_score_bin& binAt(const size_t n)const
                     {
-                        assert(n < binCount());
+                       INTEROP_ASSERT(n < binCount());
                         return m_qscoreBins[n];
                     }
                     /** Get the q-score bins
@@ -151,7 +166,7 @@ namespace illumina {
                      * @param qval q-value
                      * @return index;
                      */
-                    size_t index_for_q_value(size_t qval)const
+                    size_t index_for_q_value(const size_t qval)const
                     {
                         if(m_qscoreBins.size() == 0) return qval;
                         size_t index=0;
@@ -260,9 +275,9 @@ namespace illumina {
                      *
                      * @return q-score value of the histogram
                      */
-                    uint_t qscoreHist(size_t n)const
+                    uint_t qscoreHist(const size_t n)const
                     {
-                        assert(n<m_qscoreHist.size());
+                       INTEROP_ASSERT(n<m_qscoreHist.size());
                         return m_qscoreHist[n];
                     }
                     /** Q-score histogram
@@ -310,12 +325,12 @@ namespace illumina {
                      * @param bins q-score histogram bins
                      * @return total of clusters over the given q-score
                      */
-                    uint_t total_over_qscore(uint_t qscore, const qscore_bin_vector_type& bins=qscore_bin_vector_type())const
+                    uint_t total_over_qscore(const uint_t qscore, const qscore_bin_vector_type& bins=qscore_bin_vector_type())const
                     {
                         uint_t totalCount=0;
                         if(bins.size() == 0)
                         {
-                            assert(qscore > 0);
+                           INTEROP_ASSERT(qscore > 0);
                             totalCount = std::accumulate(m_qscoreHist.begin()+qscore-1, m_qscoreHist.end(), 0);
                         }
                         else
@@ -339,14 +354,14 @@ namespace illumina {
                      * @param bins q-score histogram bins
                      * @return total of clusters over the given q-score
                      */
-                    uint_t total_over_qscore_cumulative(uint_t qscore,
+                    uint_t total_over_qscore_cumulative(const uint_t qscore,
                                                         const qscore_bin_vector_type &bins = qscore_bin_vector_type())const
                     {
-                        assert(m_qscoreHist_cumulative.size() > 0);
+                       INTEROP_ASSERT(m_qscoreHist_cumulative.size() > 0);
                         uint_t totalCount=0;
                         if(bins.size() == 0)
                         {
-                            assert(qscore > 0);
+                           INTEROP_ASSERT(qscore > 0);
                             totalCount = std::accumulate(m_qscoreHist_cumulative.begin() + qscore - 1, m_qscoreHist_cumulative.end(), 0);
                         }
                         else
@@ -372,7 +387,8 @@ namespace illumina {
                      * @param bins q-score histogram bins
                      * @return percent of cluster over the given q-score
                      */
-                    float percent_over_qscore(uint_t qscore, const qscore_bin_vector_type& bins=qscore_bin_vector_type())const
+                    float percent_over_qscore(const uint_t qscore,
+                                              const qscore_bin_vector_type& bins=qscore_bin_vector_type())const
                     {
                         const float total = static_cast<float>(sum_qscore());
                         if(total == 0.0f) return std::numeric_limits<float>::quiet_NaN();
@@ -390,10 +406,11 @@ namespace illumina {
                      * @param bins q-score histogram bins
                      * @return percent of cluster over the given q-score
                      */
-                    float percent_over_qscore_cumulative(uint_t qscore,
-                                                         const qscore_bin_vector_type &bins = qscore_bin_vector_type())const
+                    float percent_over_qscore_cumulative(const uint_t qscore,
+                                                         const qscore_bin_vector_type &bins =
+                                                         qscore_bin_vector_type())const
                     {
-                        assert(m_qscoreHist_cumulative.size() > 0);
+                       INTEROP_ASSERT(m_qscoreHist_cumulative.size() > 0);
                         const float total = static_cast<float>(sum_qscore_cumulative());
                         if(total == 0.0f) return std::numeric_limits<float>::quiet_NaN();
                         uint_t totalCount= total_over_qscore_cumulative(qscore, bins);

--- a/interop/model/metrics/tile_metric.h
+++ b/interop/model/metrics/tile_metric.h
@@ -11,7 +11,6 @@
  *  @copyright GNU Public License.
  */
 #pragma once
-#include <assert.h>
 #include <cstring>
 #include <fstream>
 #include <map>
@@ -40,10 +39,10 @@ namespace illumina {
                      * @param percentPhasing percent phasing
                      * @param percentPrePhasing percent pre-phasing
                      */
-                    read_metric(uint_t read=0,
-                                float percentAligned=std::numeric_limits<float>::quiet_NaN(),
-                                float percentPhasing=std::numeric_limits<float>::quiet_NaN(),
-                                float percentPrePhasing=std::numeric_limits<float>::quiet_NaN()) :
+                    read_metric(const uint_t read=0,
+                                const float percentAligned=0,
+                                const float percentPhasing=0,
+                                const float percentPrePhasing=0) :
                             m_read(read),
                             m_percent_aligned(percentAligned),
                             m_percent_phasing(percentPhasing),

--- a/interop/model/run_metrics.h
+++ b/interop/model/run_metrics.h
@@ -404,12 +404,17 @@ private:
         template<class MetricSet>
         int operator()(MetricSet& metrics)const
         {
-            try
-            {
+            try {
                 io::read_interop(m_run_folder, metrics);
             }
-            catch(const io::file_not_found_exception&){return 1;}
-            catch(const io::incomplete_file_exception&){return 2;}
+            catch (const io::file_not_found_exception &) {
+                try {
+                    io::read_interop(m_run_folder, metrics, false /** Search for XMetrics.bin not XMetricsOut.bin */);
+                }
+                catch (const io::file_not_found_exception &) { return 1; }
+                catch (const io::incomplete_file_exception &) { return 2; }
+            }
+            catch (const io::incomplete_file_exception &) { return 2; }
             return 0;
         }
         std::string m_run_folder;

--- a/src/interop/model/metrics/corrected_intensity_metric.cpp
+++ b/src/interop/model/metrics/corrected_intensity_metric.cpp
@@ -75,6 +75,10 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 /** Metric ID type */
                 typedef layout::base_cycle_metric metric_id_t;
+                /** Intensity type */
+                typedef ::uint16_t intensity_t;
+                /** Count type */
+                typedef ::uint32_t count_t;
                 /** Map reading/writing to stream
                  *
                  * Reading and writing are symmetric operations, map it once
@@ -87,10 +91,10 @@ namespace illumina{ namespace interop{ namespace io {
                 static std::streamsize map_stream(Stream& stream, Metric& metric, Header&, const bool)
                 {
                     std::streamsize count = 0;
-                    count += stream_map< ::uint16_t >(stream, metric.m_averageCycleIntensity);
-                    count += stream_map< ::uint16_t >(stream, metric.m_correctedIntAll, constants::NUM_OF_BASES);
-                    count += stream_map< ::uint16_t >(stream, metric.m_correctedIntCalled, constants::NUM_OF_BASES);
-                    count += stream_map< ::uint32_t >(stream, metric.m_calledCounts, constants::NUM_OF_BASES_AND_NC);
+                    count += stream_map< intensity_t >(stream, metric.m_averageCycleIntensity);
+                    count += stream_map< intensity_t >(stream, metric.m_correctedIntAll, constants::NUM_OF_BASES);
+                    count += stream_map< intensity_t >(stream, metric.m_correctedIntCalled, constants::NUM_OF_BASES);
+                    count += stream_map< count_t >(stream, metric.m_calledCounts, constants::NUM_OF_BASES_AND_NC);
                     count += stream_map< float >(stream, metric.m_signalToNoise);
                     return count;
                 }
@@ -102,10 +106,10 @@ namespace illumina{ namespace interop{ namespace io {
                 {
                     return static_cast<record_size_t>(
                             sizeof(metric_id_t)+
-                                    sizeof(::uint16_t) +                                // m_averageCycleIntensity
-                                    sizeof(::uint16_t)*constants::NUM_OF_BASES +        // m_correctedIntAll
-                                    sizeof(::uint16_t)*constants::NUM_OF_BASES +        // m_correctedIntCalled
-                                    sizeof(::uint32_t)*constants::NUM_OF_BASES_AND_NC + // m_calledCounts
+                                    sizeof(intensity_t) +                                // m_averageCycleIntensity
+                                    sizeof(intensity_t)*constants::NUM_OF_BASES +        // m_correctedIntAll
+                                    sizeof(intensity_t)*constants::NUM_OF_BASES +        // m_correctedIntCalled
+                                    sizeof(count_t)*constants::NUM_OF_BASES_AND_NC + // m_calledCounts
                                     sizeof(float)                                       // m_signalToNoise
                     );
                 }
@@ -115,7 +119,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const corrected_intensity_metric::header_type&)
                 {
-                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
+                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(version_t));
                 }
             };
             /** Corrected Intensity Metric Record Layout Version 3
@@ -169,6 +173,10 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 /** Metric ID type */
                 typedef layout::base_cycle_metric metric_id_t;
+                /** Intensity type */
+                typedef ::uint16_t intensity_t;
+                /** Count type */
+                typedef ::uint32_t count_t;
                 /** Map reading/writing to stream
                  *
                  * Reading and writing are symmetric operations, map it once
@@ -182,8 +190,8 @@ namespace illumina{ namespace interop{ namespace io {
                 {
                     std::streamsize count = 0;
                     // TODO: this does not need header layout, audit rest to see if that is true
-                    count += stream_map< ::uint16_t >(stream, metric.m_correctedIntCalled, constants::NUM_OF_BASES);
-                    count += stream_map< ::uint32_t >(stream, metric.m_calledCounts, constants::NUM_OF_BASES_AND_NC);
+                    count += stream_map< intensity_t >(stream, metric.m_correctedIntCalled, constants::NUM_OF_BASES);
+                    count += stream_map< count_t >(stream, metric.m_calledCounts, constants::NUM_OF_BASES_AND_NC);
                     return count;
                 }
                 /** Compute the layout size
@@ -194,8 +202,8 @@ namespace illumina{ namespace interop{ namespace io {
                 {
                     return static_cast<record_size_t>(
                             sizeof(metric_id_t)+
-                            sizeof(::uint16_t)*constants::NUM_OF_BASES +        // m_correctedIntCalled
-                            sizeof(::uint32_t)*constants::NUM_OF_BASES_AND_NC   // m_calledCounts
+                            sizeof(intensity_t)*constants::NUM_OF_BASES +    // m_correctedIntCalled
+                            sizeof(count_t)*constants::NUM_OF_BASES_AND_NC   // m_calledCounts
                     );
                 }
                 /** Compute header size
@@ -204,7 +212,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const corrected_intensity_metric::header_type&)
                 {
-                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
+                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(version_t));
                 }
             };
 #pragma pack()

--- a/src/interop/model/metrics/error_metric.cpp
+++ b/src/interop/model/metrics/error_metric.cpp
@@ -64,6 +64,10 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 /** Metric ID type */
                 typedef layout::base_cycle_metric metric_id_t;
+                /** Error type */
+                typedef float error_t;
+                /** Error type */
+                typedef ::uint32_t count_t;
                 /** Map reading/writing to stream
                  *
                  * Reading and writing are symmetric operations, map it once
@@ -76,8 +80,8 @@ namespace illumina{ namespace interop{ namespace io {
                 static std::streamsize map_stream(Stream& stream, Metric& metric, Header&, const bool)
                 {
                     std::streamsize count = 0;
-                    count += stream_map< float >(stream, metric.m_errorRate);
-                    count += stream_map< ::uint32_t >(stream, metric.m_mismatch_cluster_count, error_metric::MAX_MISMATCH);
+                    count += stream_map< error_t >(stream, metric.m_errorRate);
+                    count += stream_map< count_t >(stream, metric.m_mismatch_cluster_count, error_metric::MAX_MISMATCH);
                     return count;
                 }
                 /** Compute the layout size
@@ -87,8 +91,8 @@ namespace illumina{ namespace interop{ namespace io {
                 static record_size_t computeSize(const error_metric::header_type&)
                 {
                     return static_cast<record_size_t>(sizeof(metric_id_t)+
-                            sizeof(float)+                                  // m_errorRate
-                            sizeof(::uint32_t)*error_metric::MAX_MISMATCH   // m_mismatch_cluster_count
+                            sizeof(error_t)+                                  // m_errorRate
+                            sizeof(count_t)*error_metric::MAX_MISMATCH   // m_mismatch_cluster_count
                     );
                 }
                 /** Compute header size
@@ -97,7 +101,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const error_metric::header_type&)
                 {
-                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
+                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(version_t));
                 }
 
             };

--- a/src/interop/model/metrics/extraction_metric.cpp
+++ b/src/interop/model/metrics/extraction_metric.cpp
@@ -67,6 +67,12 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 /** Metric ID type */
                 typedef layout::base_cycle_metric metric_id_t;
+                /** Intensity type */
+                typedef float focus_t;
+                /** Intensity type */
+                typedef ::uint16_t intensity_t;
+                /** Time type */
+                typedef ::uint64_t datetime_t;
                 /** Map reading/writing to stream
                  *
                  * Reading and writing are symmetric operations, map it once
@@ -79,9 +85,9 @@ namespace illumina{ namespace interop{ namespace io {
                 static std::streamsize map_stream(Stream& stream, Metric& metric, Header&, const bool)
                 {
                     std::streamsize count = 0;
-                    count += stream_map< float >(stream, metric.m_focusScores, extraction_metric::MAX_CHANNELS);
-                    count += stream_map< ::uint16_t >(stream, metric.m_max_intensity_values, extraction_metric::MAX_CHANNELS);
-                    count += stream_map< ::uint64_t >(stream, metric.m_date_time_csharp.value);
+                    count += stream_map< focus_t >(stream, metric.m_focusScores, extraction_metric::MAX_CHANNELS);
+                    count += stream_map< intensity_t >(stream, metric.m_max_intensity_values, extraction_metric::MAX_CHANNELS);
+                    count += stream_map< datetime_t >(stream, metric.m_date_time_csharp.value);
                     convert_datetime(stream, metric);
                     return count;
                 }
@@ -93,9 +99,9 @@ namespace illumina{ namespace interop{ namespace io {
                 {
                     return static_cast<record_size_t>(
                             sizeof(metric_id_t)+
-                            sizeof(float)*extraction_metric::MAX_CHANNELS +     // m_focusScores
-                            sizeof(::uint16_t)*extraction_metric::MAX_CHANNELS+ // m_max_intensity_values
-                            sizeof(::uint64_t)                                  // m_dateTime
+                            sizeof(focus_t)*extraction_metric::MAX_CHANNELS +     // m_focusScores
+                            sizeof(intensity_t)*extraction_metric::MAX_CHANNELS+ // m_max_intensity_values
+                            sizeof(datetime_t)                                  // m_dateTime
                     );
                 }
                 /** Compute header size
@@ -104,7 +110,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const extraction_metric::header_type&)
                 {
-                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
+                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(version_t));
                 }
             private:
                 static void convert_datetime(std::ostream&, const extraction_metric&)

--- a/src/interop/model/metrics/image_metric.cpp
+++ b/src/interop/model/metrics/image_metric.cpp
@@ -64,12 +64,16 @@ namespace illumina{ namespace interop{ namespace io {
                 typedef layout::base_cycle_metric metric_id_t;
                 /** Record type */
                 typedef generic_layout<image_metric, 1> record_t;
+                /** Channel type */
+                typedef ::uint16_t channel_t;
+                /** Contrast type */
+                typedef ::uint16_t contrast_t;
                 /** Channel */
-                ::uint16_t channel;
+                channel_t channel;
                 /**  Minimum contrast */
-                ::uint16_t minContrast;
+                contrast_t minContrast;
                 /** Maximum contrast */
-                ::uint16_t maxContrast;
+                contrast_t maxContrast;
                 /** Read metric from the input stream
                  *
                  * @param stream input stream
@@ -103,9 +107,9 @@ namespace illumina{ namespace interop{ namespace io {
                     for(image_metric::ushort_t channelIndex=0;channelIndex < image_metric::MAX_CHANNELS;++channelIndex)
                     {
                         if(channelIndex > 0) write_binary(stream, metric_id);
-                        count += stream_map< ::uint16_t >(stream, channelIndex);
-                        count += stream_map< ::uint16_t >(stream, metric.m_minContrast[channelIndex]);
-                        count += stream_map< ::uint16_t >(stream, metric.m_maxContrast[channelIndex]);
+                        count += stream_map< channel_t >(stream, channelIndex);
+                        count += stream_map< contrast_t >(stream, metric.m_minContrast[channelIndex]);
+                        count += stream_map< contrast_t >(stream, metric.m_maxContrast[channelIndex]);
                     }
                     return count;
                 }
@@ -125,7 +129,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const image_metric::header_type&)
                 {
-                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
+                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(version_t));
                 }
             };
 
@@ -179,6 +183,10 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 /** Metric ID type */
                 typedef layout::base_cycle_metric metric_id_t;
+                /** Contrast type */
+                typedef ::uint16_t contrast_t;
+                /** Contrast type */
+                typedef ::uint8_t channel_count_t;
 
                 /** Map reading/writing a metric to a stream
                  *
@@ -194,8 +202,8 @@ namespace illumina{ namespace interop{ namespace io {
                 {
                     std::streamsize count = 0;
                     copy_from(stream, metric.m_channelCount, header.m_channelCount);
-                    count += stream_map< ::uint16_t >(stream, metric.m_minContrast, header.m_channelCount);
-                    count += stream_map< ::uint16_t >(stream, metric.m_maxContrast, header.m_channelCount);
+                    count += stream_map< contrast_t >(stream, metric.m_minContrast, header.m_channelCount);
+                    count += stream_map< contrast_t >(stream, metric.m_maxContrast, header.m_channelCount);
                     return count;
                 }
                 /** Compute the layout size
@@ -204,7 +212,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeSize(const image_metric::header_type& header)
                 {
-                    return static_cast<record_size_t>(sizeof(metric_id_t)+header.channelCount()*sizeof(::uint16_t)*2);
+                    return static_cast<record_size_t>(sizeof(metric_id_t)+header.channelCount()*sizeof(contrast_t)*2);
                 }
                 /** Map reading/writing a header to a stream
                  *
@@ -217,7 +225,7 @@ namespace illumina{ namespace interop{ namespace io {
                 template<class Stream, class Header>
                 static std::streamsize map_stream_for_header(Stream& stream, Header& header)
                 {
-                    return stream_map< ::uint8_t >(stream, header.m_channelCount);
+                    return stream_map< channel_count_t >(stream, header.m_channelCount);
                 }
                 /** Compute header size
                  *
@@ -225,7 +233,7 @@ namespace illumina{ namespace interop{ namespace io {
                  */
                 static record_size_t computeHeaderSize(const image_metric::header_type&)
                 {
-                    return static_cast<record_size_t>(sizeof(::uint8_t) + sizeof(record_size_t) + sizeof(::uint8_t));
+                    return static_cast<record_size_t>(sizeof(channel_count_t) + sizeof(record_size_t) + sizeof(version_t));
                 }
             };
 #pragma pack() // DO NOT MOVE

--- a/src/interop/model/metrics/index_metric.cpp
+++ b/src/interop/model/metrics/index_metric.cpp
@@ -138,7 +138,7 @@ struct generic_layout<index_metric, 1> : public default_layout<1>
      */
     static size_t computeHeaderSize(const index_metric::header_type&)
     {
-        return sizeof(::uint8_t);
+        return sizeof(version_t);
     }
 };
 

--- a/src/interop/model/metrics/tile_metric.cpp
+++ b/src/interop/model/metrics/tile_metric.cpp
@@ -63,6 +63,10 @@ namespace illumina{ namespace interop{
                 typedef layout::base_metric metric_id_t;
                 /** Record type */
                 typedef generic_layout<tile_metric, 2> record_t;
+                /** Code type */
+                typedef ::uint16_t code_t;
+                /** Value type */
+                typedef float value_t;
                 /** Code for each tile metric
                  */
                 enum TileMetricCode
@@ -77,9 +81,9 @@ namespace illumina{ namespace interop{
                     ControlLane = 400
                 };
                 /** Tile Metric Code */
-                ::uint16_t code;
+                code_t code;
                 /** Tile Metric Value */
-                float value;
+                value_t value;
 
                 /** Read metric from the input stream
                  *
@@ -189,16 +193,16 @@ namespace illumina{ namespace interop{
                     for(const_iterator beg = metric.read_metrics().begin();beg != metric.read_metrics().end();beg++)
                     {
                         const int read = beg->read()-1;
-                        rec.code = static_cast< ::uint16_t >(Prephasing+read*2);
+                        rec.code = static_cast< code_t >(Prephasing+read*2);
                         rec.value = beg->percent_prephasing();
                         if(write_id) write_binary(out, metric_id);
                         write_id=true;
                         write_binary(out, rec);
-                        rec.code = static_cast< ::uint16_t >(Phasing+read*2);
+                        rec.code = static_cast< code_t >(Phasing+read*2);
                         rec.value = beg->percent_phasing();
                         write_binary(out, metric_id);
                         write_binary(out, rec);
-                        rec.code = static_cast< ::uint16_t >(PercentAligned+read);
+                        rec.code = static_cast< code_t >(PercentAligned+read);
                         rec.value = beg->percent_aligned();
                         write_binary(out, metric_id);
                         write_binary(out, rec);
@@ -219,7 +223,7 @@ namespace illumina{ namespace interop{
                  */
                 static record_size_t computeHeaderSize(const tile_metric::header_type&)
                 {
-                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(::uint8_t));
+                    return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(version_t));
                 }
 
             private:

--- a/src/tests/interop/metrics/base_metric_tests.cpp
+++ b/src/tests/interop/metrics/base_metric_tests.cpp
@@ -7,14 +7,14 @@
  *  @copyright GNU Public License.
  */
 #include <gtest/gtest.h>
-#include "interop/io/layout/base_metric.h"
+#include "interop/model/metric_base/base_metric.h"
 
 #ifdef _MSC_VER
 #pragma warning(push)
     #pragma warning(disable:4127) // MSVC warns about using constants in conditional statements, for template constants
 #endif
 
-using namespace illumina::interop::io::layout;
+using namespace illumina::interop::model::metric_base;
 
 
 TEST(base_metric_test, lane_from_id)


### PR DESCRIPTION
This is generally a clean up of the code to make it more readable.

I also added a fall back if, for example, TileMetrics.bin exists but TileMetricsOut.bin does not.
