### PR TITLE
IPA-4283: Update all cycle states

### DIFF
--- a/interop/logic/metric/q_metric.h
+++ b/interop/logic/metric/q_metric.h
@@ -181,7 +181,7 @@ namespace illumina { namespace interop { namespace logic { namespace metric {
      * This only for legacy platforms that use older q-metric formats, which do not include bin information
      * in the header.
      *
-     * @param set q_metric set
+     * @param metrics q_metric set
      * @param q_score_bins vector of q-score bins
      * @param instrument type
      */
@@ -189,5 +189,35 @@ namespace illumina { namespace interop { namespace logic { namespace metric {
     {
         const size_t count = count_legacy_q_score_bins(metrics);
         populate_legacy_q_score_bins(q_score_bins, instrument, count);
+    }
+    /** Test whether the q-values are compressed
+     *
+     * @param set q_metric set
+     * @return number of q-vals
+     */
+    inline size_t count_qvals(const model::metric_base::metric_set<model::metrics::q_metric>& metrics)
+    {
+        return metrics.size() > 0 ? metrics.metrics()[0].size() : 0;
+    }
+    /** Test whether the q-values are compressed
+     *
+     * @param set q_metric set
+     * @return true if the histogram is compressed (no all zero columns)
+     */
+    inline bool is_compressed(const model::metric_base::metric_set<model::metrics::q_metric>& metrics)
+    {
+        const size_t q_val_count = count_qvals(metrics);
+        return q_val_count > 0 && q_val_count != 50;
+    }
+    /** Get the index for the given q-value
+     *
+     * @param metrics q_metric set
+     * @param qval threshold
+     * @return index of q-val above given threshold
+     */
+    inline size_t index_for_q_value(const model::metric_base::metric_set<model::metrics::q_metric>& metrics, const size_t qval)
+    {
+        if(!is_compressed(metrics)) return qval;
+        return metrics.index_for_q_value(qval);
     }
 }}}}

--- a/interop/logic/summary/cycle_state_summary.h
+++ b/interop/logic/summary/cycle_state_summary.h
@@ -1,0 +1,92 @@
+/** Update the cycle state for the summary model
+ *
+ *  @file
+ *  @date  4/21/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#pragma once
+#include "interop/logic/summary/map_cycle_to_read.h"
+
+
+namespace illumina { namespace interop { namespace logic { namespace summary {
+
+/** Define a member function of cycle_state_summary that sets a cycle state */
+typedef void (model::summary::cycle_state_summary::*set_cycle_state_func_t )(const model::run::cycle_range&);
+/** Vector of vectors of cycle_range objects */
+typedef std::vector<std::vector< model::run::cycle_range> > cycle_range_vector2d_t;
+
+/** Cache errors for all tiles up to a give max cycle
+ *
+ * This function only includes errors from useable cycles (not the last cycle).
+ *
+ * @param beg iterator to start of a collection of error metrics
+ * @param end iterator to end of a collection of error metrics
+ * @param cycle_to_read map that takes a cycle and returns the read-number cycle-in-read pair
+ * @param summary_by_lane_read destination cache by read then by lane a collection of errors
+ */
+template<typename I>
+void cache_cycle_state_by_lane_read(I beg, I end,
+                                    const read_cycle_vector_t& cycle_to_read,
+                                    cycle_range_vector2d_t& summary_by_lane_read)
+{
+    typedef std::map< size_t, model::run::cycle_range >  cycle_range_tile_t;
+    typedef std::vector< cycle_range_tile_t > cycle_range_by_read_tile_t;
+    cycle_range_by_read_tile_t tmp (summary_by_lane_read.size());
+    for(;beg != end;++beg)
+    {
+        INTEROP_ASSERT(beg->cycle() > 0);
+        INTEROP_ASSERT((beg->cycle()-1) < cycle_to_read.size());
+        const read_cycle& read = cycle_to_read[beg->cycle()-1];
+        if(read.number == 0) continue;
+        INTEROP_ASSERT((read.number-1) < tmp.size());
+        const size_t id = static_cast<size_t>(model::metric_base::base_metric::id(beg->lane(), beg->tile()));
+        tmp[read.number-1][id].update(beg->cycle());
+    }
+    for(size_t read=0;read<tmp.size();++read)
+    {
+        INTEROP_ASSERT(read < summary_by_lane_read.size());
+        for(typename cycle_range_tile_t::const_iterator ebeg = tmp[read].begin(), eend = tmp[read].end();ebeg != eend;++ebeg)
+        {
+            const size_t lane = static_cast<size_t>(model::metric_base::base_metric::lane_from_id(ebeg->first)-1);
+            INTEROP_ASSERT(lane < summary_by_lane_read[read].size());
+            summary_by_lane_read[read][lane].update(ebeg->second.last_cycle());
+        }
+    }
+}
+
+
+/** Summarize the cycle state for a particular metric
+ *
+ * @param beg iterator to start of a collection of error metrics
+ * @param end iterator to end of a collection of error metrics
+ * @param cycle_to_read map cycle to the read number and cycle within read number
+ * @param pointer to function that sets a cycle state
+ * @param run destination run summary
+ */
+template<typename I>
+void summarize_cycle_state(I beg,
+                           I end,
+                           const read_cycle_vector_t& cycle_to_read,
+                           set_cycle_state_func_t set_cycle_state_fun,
+                           model::summary::run_summary &run) throw( model::index_out_of_bounds_exception )
+{
+
+
+    cycle_range_vector2d_t cycle_range(run.size(), std::vector< model::run::cycle_range>(run.lane_count()));
+    cache_cycle_state_by_lane_read(beg, end, cycle_to_read, cycle_range);
+
+    model::run::cycle_range overall_cycle_state;
+    for(size_t read=0;read<run.size();++read)
+    {
+        for (size_t lane = 0; lane < run[read].size(); ++lane)
+        {
+            (run[read][lane].cycle_state().*set_cycle_state_fun)(
+                    cycle_range[read][lane] - (run[read].read().first_cycle()-1));
+            overall_cycle_state.update(cycle_range[read][lane]);
+        }
+    }
+    (run.cycle_state().*set_cycle_state_fun)(overall_cycle_state);
+}
+
+}}}}

--- a/interop/logic/summary/map_cycle_to_read.h
+++ b/interop/logic/summary/map_cycle_to_read.h
@@ -1,0 +1,79 @@
+/** Map each cycle to its read info
+ *
+ *  @file
+ *  @date  4/20/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#pragma once
+#include <vector>
+#include <map>
+#include "interop/logic/summary/summary_statistics.h"
+#include "interop/model/metric_base/base_metric.h"
+
+namespace illumina { namespace interop { namespace logic { namespace summary {
+
+
+/** Read number and cycle in read
+ */
+struct read_cycle
+{
+    /** Constructor
+     *
+     * @param r read number
+     * @param c cycle in read
+     */
+    read_cycle(const size_t r = 0, const size_t c = 0) : number(r), cycle_within_read(c), is_last_cycle_in_read(false) { }
+
+    /** Read number */
+    size_t number;
+    /** Cycle within read */
+    size_t cycle_within_read;
+    /** Is last cycle in read */
+    bool is_last_cycle_in_read;
+};
+
+/** Vector of read_cycle objects */
+typedef std::vector<read_cycle> read_cycle_vector_t;
+
+/** Create a map from cycle to a pair: read number and cycle in read
+ *
+ * @param beg iterator to start of a collection of read infos
+ * @param end iterator to end of a collection of read infos
+ * @param cycle_to_read map that takes a cycle and returns the read-number cycle-in-read pair
+ * @param op unary operator that takes some object and returns a read info
+ */
+template<typename I, typename UnaryOp>
+void map_read_to_cycle_number(I beg, I end, read_cycle_vector_t& cycle_to_read, UnaryOp op)
+{
+    cycle_to_read.resize(std::accumulate(beg, end, size_t(0), op::total_cycle_sum<UnaryOp>(op)));
+    std::fill(cycle_to_read.begin(), cycle_to_read.end(), 0);
+    for(;beg != end;++beg)
+    {
+        for(size_t cycle=op(*beg).first_cycle()-1, last_cycle=op(*beg).last_cycle(), cycle_in_read=1;
+            cycle < last_cycle;++cycle_in_read, ++cycle)
+        {
+            INTEROP_ASSERT(cycle < cycle_to_read.size());
+            cycle_to_read[cycle] = read_cycle(op(*beg).number(), cycle_in_read);
+        }
+        INTEROP_ASSERT((op(*beg).last_cycle()-1) < cycle_to_read.size());
+        cycle_to_read[op(*beg).last_cycle()-1].is_last_cycle_in_read = true;
+    }
+}
+/** Create a map from cycle to a pair: read number and cycle in read
+ *
+ * @param beg iterator to start of a collection of read infos
+ * @param end iterator to end of a collection of read infos
+ * @param cycle_to_read map that takes a cycle and returns the read-number cycle-in-read pair
+ */
+template<typename I>
+void map_read_to_cycle_number(I beg, I end, read_cycle_vector_t& cycle_to_read)
+{
+    map_read_to_cycle_number(beg, end, cycle_to_read, op::default_get_read());
+}
+
+
+
+
+
+}}}}

--- a/interop/model/metrics/q_metric.h
+++ b/interop/model/metrics/q_metric.h
@@ -159,10 +159,12 @@ namespace illumina {
                      */
                     q_score_bin::bin_type max_q_value()const
                     {
-                        return m_bin_count == static_cast<size_t>(MAX_Q_BINS) || m_bin_count == 0 ? static_cast<q_score_bin::bin_type>(MAX_Q_BINS) : m_qscoreBins.back().upper();
+                        return m_bin_count == static_cast<size_t>(MAX_Q_BINS) ||
+                                       m_bin_count == 0 ? static_cast<q_score_bin::bin_type>(MAX_Q_BINS) : m_qscoreBins.back().upper();
                     }
                     /** Get the index for the given q-value
                      *
+                     * @note Never call this function directly, use interop::logic::metric::index_for_q_value
                      * @param qval q-value
                      * @return index;
                      */

--- a/interop/model/summary/cycle_state_summary.h
+++ b/interop/model/summary/cycle_state_summary.h
@@ -48,7 +48,7 @@ public:
     }
     /** Get the base called cycle range
      *
-     * @return  base called cycle range
+     * @return base called cycle range
      */
     const run::cycle_range& called_cycle_range()const
     {

--- a/src/apps/cyclesim.cpp
+++ b/src/apps/cyclesim.cpp
@@ -274,7 +274,14 @@ int copy_cycle_metrics(const std::string& input, const std::string& output, unsi
 
     for(const_iterator beg = metrics.metrics().begin(), end=metrics.metrics().end();beg != end;++beg)
     {
-        if(beg->cycle() > max_cycle) continue;
+        if(beg->tile()%2==0 && max_cycle > 1)
+        {
+            if (beg->cycle() > (max_cycle-1)) continue;
+        }
+        else
+        {
+            if (beg->cycle() > max_cycle) continue;
+        }
         subset.push_back(*beg);
     }
 

--- a/src/apps/summary.cpp
+++ b/src/apps/summary.cpp
@@ -312,4 +312,7 @@ void print_summary(std::ostream& out, const run_summary& summary)
             print_array(out, values, width);
         }
     }
+    out << "Extracted: " << format(summary.cycle_state().extracted_cycle_range()) << "\n";
+    out << "Called: " << format(summary.cycle_state().called_cycle_range()) << "\n";
+    out << "Scored: " << format(summary.cycle_state().qscored_cycle_range()) << "\n";
 }

--- a/src/ext/swig/interop.i
+++ b/src/ext/swig/interop.i
@@ -150,8 +150,15 @@ WRAP_TEMPLATE_BASE(index_metric)
 %ignore illumina::interop::model::summary::run_summary::end;
 %ignore illumina::interop::model::summary::run_summary::operator[];
 
+
 %{
 #include "interop/model/run/cycle_range.h"
+#include "interop/model/run/read_info.h"
+%}
+%include "interop/model/run/cycle_range.h"
+%include "interop/model/run/read_info.h"
+
+%{
 #include "interop/model/summary/cycle_state_summary.h"
 #include "interop/model/summary/metric_summary.h"
 #include "interop/model/summary/lane_summary.h"
@@ -164,7 +171,6 @@ WRAP_TEMPLATE_BASE(index_metric)
 #include "interop/model/run/image_dimensions.h"
 #include "interop/model/run/info.h"
 #include "interop/model/run/parameters.h"
-#include "interop/model/run/read_info.h"
 
 #include "interop/model/run_metrics.h"
 #include "interop/logic/metric/q_metric.h"
@@ -172,7 +178,6 @@ WRAP_TEMPLATE_BASE(index_metric)
 %}
 
 
-%include "interop/model/run/cycle_range.h"
 %include "interop/model/summary/cycle_state_summary.h"
 %include "interop/model/summary/metric_summary.h"
 %include "interop/model/summary/lane_summary.h"
@@ -184,7 +189,6 @@ WRAP_TEMPLATE_BASE(index_metric)
 %include "interop/model/run/image_dimensions.h"
 %include "interop/model/run/info.h"
 %include "interop/model/run/parameters.h"
-%include "interop/model/run/read_info.h"
 
 //
 // Setup typemaps for summary metrics

--- a/src/interop/CMakeLists.txt
+++ b/src/interop/CMakeLists.txt
@@ -1,5 +1,4 @@
 
-
 set(SRCS
         model/run/info.cpp
         model/run/parameters.cpp
@@ -79,7 +78,7 @@ set(HEADERS
         ../../interop/util/linear_hierarchy.h
         ../../interop/util/object_list.h
         ../../interop/util/exception_specification.h
-        )
+        ../../interop/logic/summary/map_cycle_to_read.h ../../interop/logic/summary/cycle_state_summary.h)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" OR CMAKE_COMPILER_IS_GNUCC)
     foreach(SRC ${SRCS})

--- a/src/tests/interop/metrics/inc/corrected_intensity_metrics_test.h
+++ b/src/tests/interop/metrics/inc/corrected_intensity_metrics_test.h
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 #include "metric_test.h"
 #include "interop/model/metrics/corrected_intensity_metric.h"
+#include "interop/model/summary/run_summary.h"
 
 
 namespace illumina{ namespace interop { namespace unittest {
@@ -75,6 +76,32 @@ namespace illumina{ namespace interop { namespace unittest {
             };
             return to_string(tmp);
         }
+        /** Get number lanes in data
+         *
+         * @return 8 lanes
+         */
+        static size_t lane_count(){return 8;}
+        /** Get reads describing data
+         *
+         * @return reads vector
+         */
+        static std::vector<model::run::read_info> reads()
+        {
+            std::vector<model::run::read_info> reads(1, model::run::read_info(1, 1, 27, false));
+            return reads;
+        }
+        /** Get the summary for these metrics
+         *
+         * @return run summary
+         */
+        static model::summary::run_summary summary()
+        {
+            std::vector<model::run::read_info> read_infos = reads();
+            model::summary::run_summary summary(read_infos.begin(), read_infos.end(), lane_count());
+            summary[0][0].cycle_state().called_cycle_range(model::run::cycle_range(1, 25));
+            summary.cycle_state().called_cycle_range(model::run::cycle_range(1, 25));
+            return summary;
+        }
     };
 
     /** This test compares byte values taken from an InterOp file for three records produced by RTA 2.7.x
@@ -127,6 +154,32 @@ namespace illumina{ namespace interop { namespace unittest {
                          0, 0, 0, 0, 0, -48, -101, 15, 0, 51, 108, 9, 0, -108, 19, 9, 0, 17, -122, 14, 0
             };
             return to_string(tmp);
+        }
+        /** Get number lanes in data
+         *
+         * @return 8 lanes
+         */
+        static size_t lane_count(){return 8;}
+        /** Get reads describing data
+         *
+         * @return reads vector
+         */
+        static std::vector<model::run::read_info> reads()
+        {
+            std::vector<model::run::read_info> reads(1, model::run::read_info(1, 1, 27, false));
+            return reads;
+        }
+        /** Get the summary for these metrics
+         *
+         * @return run summary
+         */
+        static model::summary::run_summary summary()
+        {
+            std::vector<model::run::read_info> read_infos = reads();
+            model::summary::run_summary summary(read_infos.begin(), read_infos.end(), lane_count());
+            summary[0][0].cycle_state().called_cycle_range(model::run::cycle_range(3, 3));
+            summary.cycle_state().called_cycle_range(model::run::cycle_range(3, 3));
+            return summary;
         }
     };
     /** Interface between fixtures and Google Test */

--- a/src/tests/interop/metrics/inc/error_metrics_test.h
+++ b/src/tests/interop/metrics/inc/error_metrics_test.h
@@ -84,12 +84,12 @@ struct error_v3 : metric_test<model::metrics::error_metric, 3>
         summary[0][6].error_rate_50()=model::summary::metric_stat(00.0f, 0, 0.0f);
         summary[0][6].error_rate_75()=model::summary::metric_stat(0.0f, 0, 0.0f);
         summary[0][6].error_rate_100()=model::summary::metric_stat(0.0f, 0, 0.0f);
-        summary[0][6].cycle_state().error_cycle_range(model::run::cycle_range(2, 2));
+        summary[0][6].cycle_state().error_cycle_range(model::run::cycle_range(3, 3));
         summary[0].summary().error_rate(0.67515134811401367f);
         summary.total_summary().error_rate(0.67515134811401367f);
         summary.nonindex_summary().error_rate(0.67515134811401367f);
         summary[0][6].tile_count(1);
-        summary.cycle_state().error_cycle_range(model::run::cycle_range(2, 2));
+        summary.cycle_state().error_cycle_range(model::run::cycle_range(3, 3));
         return summary;
     }
 };

--- a/src/tests/interop/metrics/inc/extraction_metrics_test.h
+++ b/src/tests/interop/metrics/inc/extraction_metrics_test.h
@@ -91,10 +91,12 @@ namespace illumina{ namespace interop { namespace unittest {
             std::vector<model::run::read_info> read_infos = reads();
             model::summary::run_summary summary(read_infos.begin(), read_infos.end(), lane_count());
             summary[0][6].first_cycle_intensity()=model::summary::metric_stat(321, 24.75883674621582f, 312);
+            summary[0][6].cycle_state().extracted_cycle_range(model::run::cycle_range(1, 1));
             summary[0].summary().first_cycle_intensity(321);
             summary.total_summary().first_cycle_intensity(321);
             summary.nonindex_summary().first_cycle_intensity(321);
             summary[0][6].tile_count(3);
+            summary.cycle_state().extracted_cycle_range(model::run::cycle_range(1, 1));
             return summary;
         }
     };

--- a/src/tests/interop/metrics/inc/q_metrics_test.h
+++ b/src/tests/interop/metrics/inc/q_metrics_test.h
@@ -107,6 +107,7 @@ namespace illumina{ namespace interop { namespace unittest {
             summary[0][0].projected_yield_g(0.0098816361278295517);
             summary[0][0].yield_g(0.0074112270958721638f);
             summary[0][0].percent_gt_q30(95.733200073242188f);
+            summary[0][0].cycle_state().qscored_cycle_range(model::run::cycle_range(1, 2));
             summary[0].summary().projected_yield_g(0.0098816361278295517);
             summary[0].summary().yield_g(0.0074112270958721638f);
             summary[0].summary().percent_gt_q30(95.733200073242188f);
@@ -116,6 +117,7 @@ namespace illumina{ namespace interop { namespace unittest {
             summary.nonindex_summary().percent_gt_q30(95.733200073242188f);
             summary.nonindex_summary().projected_yield_g(0.0098816361278295517);
             summary.nonindex_summary().yield_g(0.0074112270958721638f);
+            summary.cycle_state().qscored_cycle_range(model::run::cycle_range(1, 2));
             return summary;
         }
     };
@@ -221,6 +223,7 @@ namespace illumina{ namespace interop { namespace unittest {
             summary[0][0].projected_yield_g(0.0056276721879839897f);
             summary[0][0].yield_g(0.0056276721879839897f);
             summary[0][0].percent_gt_q30(95.650672912597656f);
+            summary[0][0].cycle_state().qscored_cycle_range(model::run::cycle_range(1, 1));
             summary[0].summary().projected_yield_g(0.0056276721879839897f);
             summary[0].summary().yield_g(0.0056276721879839897f);
             summary[0].summary().percent_gt_q30(95.650672912597656f);
@@ -230,6 +233,7 @@ namespace illumina{ namespace interop { namespace unittest {
             summary.nonindex_summary().percent_gt_q30(95.650672912597656f);
             summary.nonindex_summary().projected_yield_g(0.0056276721879839897f);
             summary.nonindex_summary().yield_g(0.0056276721879839897);
+            summary.cycle_state().qscored_cycle_range(model::run::cycle_range(1, 1));
             return summary;
         }
     };
@@ -321,6 +325,7 @@ namespace illumina{ namespace interop { namespace unittest {
             summary[0][6].projected_yield_g(0.0095612816512584686f);
             summary[0][6].yield_g(0.009561280719935894f);
             summary[0][6].percent_gt_q30(90.1163330078125f);
+            summary[0][6].cycle_state().qscored_cycle_range(model::run::cycle_range(3, 3));
             summary[0].summary().projected_yield_g(0.0095612816512584686f);
             summary[0].summary().yield_g(0.0095612816512584686f);
             summary[0].summary().percent_gt_q30(90.1163330078125f);
@@ -330,6 +335,7 @@ namespace illumina{ namespace interop { namespace unittest {
             summary.nonindex_summary().percent_gt_q30(90.1163330078125f);
             summary.nonindex_summary().projected_yield_g(0.0095612816512584686f);
             summary.nonindex_summary().yield_g(0.0095612816512584686f);
+            summary.cycle_state().qscored_cycle_range(model::run::cycle_range(3, 3));
             return summary;
         }
     };

--- a/src/tests/interop/metrics/summary_metrics_test.cpp
+++ b/src/tests/interop/metrics/summary_metrics_test.cpp
@@ -143,6 +143,7 @@ TYPED_TEST(summary_metrics_test, lane_summary)
 
             const model::summary::cycle_state_summary& actual_cycle_summary = actual_lane_summary.cycle_state();
             const model::summary::cycle_state_summary& expected_cycle_summary = expected_lane_summary.cycle_state();
+            EXPECT_CYCLE_EQ(actual_cycle_summary.called_cycle_range(), expected_cycle_summary.called_cycle_range());
             EXPECT_CYCLE_EQ(actual_cycle_summary.extracted_cycle_range(), expected_cycle_summary.extracted_cycle_range());
             EXPECT_CYCLE_EQ(actual_cycle_summary.called_cycle_range(), expected_cycle_summary.called_cycle_range());
             EXPECT_CYCLE_EQ(actual_cycle_summary.qscored_cycle_range(), expected_cycle_summary.qscored_cycle_range());


### PR DESCRIPTION
This pull request resolves #54.

- Cycle state is updated for all states (instead of just error rated)
- Code was refactored to make this implementation cleaner
- A bug was fixed for legacy q-metrics on old systems.


(cherry picked from commit cc55ac6)