### PR TITLE
IPA-4322: Make NaN checking compiler robust

### DIFF
--- a/cmake/InternalUtils.cmake
+++ b/cmake/InternalUtils.cmake
@@ -40,6 +40,8 @@ endmacro()
 macro(config_compiler_and_linker)
     fix_default_compiler_settings_()
 
+    include(CheckIsNaN)
+
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR CMAKE_COMPILER_IS_GNUCC)
         set(COMPILER_IS_GNUCC_OR_CLANG ON)
     endif()

--- a/cmake/Modules/CheckIsNaN.cmake
+++ b/cmake/Modules/CheckIsNaN.cmake
@@ -1,0 +1,52 @@
+# Ensure best isnan function is available
+# Adpoted from: https://github.com/soonhokong/fp-test/blob/master/src/cmake_modules/CheckIsNaN.cmake
+
+include(CheckCXXSourceCompiles)
+
+
+CHECK_CXX_SOURCE_COMPILES(
+        "#include <cmath>\nint main() { bool a = std::isnan(0e0); return 0; }\n"
+        HAVE_STD_ISNAN)
+
+if(HAVE_STD_ISNAN)
+    add_definitions(-DHAVE_STD_ISNAN)
+    return()
+endif()
+
+
+CHECK_CXX_SOURCE_COMPILES(
+        "#include <math.h>\nint main() { bool a = isnan(0e0); return 0; }\n"
+        HAVE_ISNAN)
+
+if(HAVE_ISNAN)
+    add_definitions(-DHAVE_ISNAN)
+    return()
+endif()
+
+CHECK_CXX_SOURCE_COMPILES(
+        "#include <math.h>\nint main() { bool a = _isnan(0e0); return 0; }\n"
+        HAVE___ISNAN)
+
+if(HAVE___ISNAN)
+    add_definitions(-DHAVE___ISNAN)
+    return()
+endif()
+
+CHECK_CXX_SOURCE_COMPILES(
+            "# include <float.h>\nint main() { bool a = _isnan(0e0); return 0; }\n"
+            HAVE_FLOAT_H_ISNAN)
+
+
+if(HAVE_FLOAT_H_ISNAN)
+    add_definitions(-DHAVE_FLOAT_H_ISNAN)
+    return()
+endif()
+
+
+CHECK_CXX_SOURCE_RUNS(
+        "#include <limits>\nint main() { const float NaN=std::numeric_limits<float>::quiet_NaN();return NaN!=NaN; }\n"
+        IS_NAN_CHECK_WORKING)
+
+if(NOT IS_NAN_CHECK_WORKING)
+    message(FATAL_ERROR "NaN checking is not working in your current configuration")
+endif()

--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -3,13 +3,31 @@
 
 ## Trunk
 
+Commit  | Description
+------- | -----------
+??????? | Enhance robustness to missing isnan functions
+         
+## v1.0.6
 
+Commit  | Description
+------- | -----------
+57be79c | Update all cycle states and bug fix for legacy q-metrics
+0b4304a | Refactor to remove and mark deprecated code
+647cc9e | Add utility for creating unit tests
+9d82333 | Add search for non Out interop files
+
+## v1.0.5
+
+Commit  | Description
+------- | -----------
+7380f29 | Bug fixes for q-metrics and compilation error on Mac OSX
 
 ## v1.0.4
 
 Commit  | Description
 ------- | -----------
-        | Update documentation
+50e8e2a | Update documentation
+50e8e2a | Update documentation
 0b22102 | Added summary tests
 13f1fb4 | Added summary logic
 339a914 | Added summary model

--- a/interop/util/math.h
+++ b/interop/util/math.h
@@ -1,0 +1,44 @@
+/** Back port of C++11 math functions
+ *
+ * @TODO include this everywhere isnan is used
+ *
+ *  @file
+ *  @date 4/20/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+
+#pragma once
+
+#if defined(HAVE_STD_ISNAN)
+#include <cmath>
+#else
+#   if defined(HAVE_ISNAN)
+#       include <math.h>
+    #elif defined(HAVE___ISNAN)
+#       include <math.h>
+    #elif defined(HAVE_FLOAT_H_ISNAN)
+#       include <float.h>
+    #endif
+    namespace std
+    {
+        /** Test if a floating point number is not a number (NaN)
+         *
+         * @param val floating point number
+         * @return true if floating point is NaN
+         */
+        template<typename T>
+        bool isnan(const T val)
+        {
+#   if defined(HAVE_ISNAN)
+            return ::isnan(val);
+#   elif defined(HAVE___ISNAN)
+            return __isnan(val);
+#   elif defined(HAVE_FLOAT_H_ISNAN)
+            return _isnan(val);
+#   else
+            return val != val;
+#endif
+        }
+    }
+#endif

--- a/interop/util/statistics.h
+++ b/interop/util/statistics.h
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cmath>
 #include "interop/util/assert.h"
+#include "interop/util/math.h"
 
 namespace illumina {
 namespace interop {

--- a/src/interop/CMakeLists.txt
+++ b/src/interop/CMakeLists.txt
@@ -78,7 +78,11 @@ set(HEADERS
         ../../interop/util/linear_hierarchy.h
         ../../interop/util/object_list.h
         ../../interop/util/exception_specification.h
-        ../../interop/logic/summary/map_cycle_to_read.h ../../interop/logic/summary/cycle_state_summary.h)
+        ../../interop/logic/summary/map_cycle_to_read.h
+        ../../interop/logic/summary/cycle_state_summary.h
+        ../../interop/util/math.h
+
+        )
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" OR CMAKE_COMPILER_IS_GNUCC)
     foreach(SRC ${SRCS})

--- a/src/tests/interop/metrics/corrected_intensity_metrics_test.cpp
+++ b/src/tests/interop/metrics/corrected_intensity_metrics_test.cpp
@@ -13,6 +13,7 @@
 #endif
 
 #include <fstream>
+#include "interop/util/math.h"
 #include "inc/corrected_intensity_metrics_test.h"
 using namespace illumina::interop::model::metrics;
 using namespace illumina::interop;

--- a/src/tests/interop/metrics/inc/extraction_metrics_test.h
+++ b/src/tests/interop/metrics/inc/extraction_metrics_test.h
@@ -22,10 +22,6 @@ namespace illumina{ namespace interop { namespace unittest {
      */
     struct extraction_v2 : metric_test<model::metrics::extraction_metric, 2>
     {
-        enum{
-            /** Do not check the expected binary data */
-           disable_binary_data=true // TODO: Move this to template?
-        };
         /** Build the expected metric set
          *
          * @return vector of metrics


### PR DESCRIPTION
Potentially, compilation could fail on older systems due to use of std::nan, which was only added to C++11.

In practice, this has yet to occur.