### PR TITLE
IPA-4815: Fix interop cmake build problems with path spaces

### DIFF
--- a/cmake/CopyListOfFiles.cmake
+++ b/cmake/CopyListOfFiles.cmake
@@ -8,7 +8,7 @@
 #   - DESTINATION_DIR - the destination directory path
 #
 #
-string (REPLACE " " ";" FILES_TO_COPY "${FILES_TO_COPY}")
+string (REPLACE "," ";" FILES_TO_COPY "${FILES_TO_COPY}")
 set(FILES_TO_COPY_EX)
 foreach(filename ${FILES_TO_COPY})
     file(GLOB GLOB_FILES ${filename})

--- a/cmake/Modules/UseCSharp.cmake
+++ b/cmake/Modules/UseCSharp.cmake
@@ -95,6 +95,7 @@ macro( CSHARP_ADD_PROJECT type name )
   set(CSHARP_OUTPUT_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
   set(CSHARP_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
+  string (REPLACE ";" "," source_list "${sources}")
   set(CSHARP_${name}_BINARY ${CSHARP_OUTPUT_DIR}/${name}.${output})
   set(CSHARP_${name}_BINARY_NAME ${name}.${output})
   # Add custom target and command
@@ -102,7 +103,7 @@ macro( CSHARP_ADD_PROJECT type name )
   add_custom_command(
     COMMENT "Compiling C# ${type} ${name}: '${CSHARP_COMPILER} /unsafe /t:${type} /out:${CSHARP_OUTPUT_DIR}/${name}.${output} /platform:${CSHARP_PLATFORM} ${CSHARP_SDK} ${refs} ${sources}'"
     OUTPUT ${CMAKE_BINARY_DIR}/${name}.${output}
-    COMMAND ${CMAKE_COMMAND} -DFILES_TO_COPY="${sources}" -DDESTINATION_DIR=${CMAKE_BINARY_DIR} -P ${CMAKE_SOURCE_DIR}/cmake/CopyListOfFiles.cmake
+    COMMAND ${CMAKE_COMMAND} -DFILES_TO_COPY="${source_list}" -DDESTINATION_DIR="${CMAKE_BINARY_DIR}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyListOfFiles.cmake"
     COMMAND ${CSHARP_COMPILER}
     ARGS /t:${type} /out:${CSHARP_OUTPUT_DIR}/${name}.${output} /unsafe /platform:${CSHARP_PLATFORM} ${CSHARP_SDK} ${refs} ${sources}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/cmake/Modules/UseGitVersion.cmake
+++ b/cmake/Modules/UseGitVersion.cmake
@@ -17,7 +17,7 @@ function(add_version_target _target _version_file _macro_name)
     file(WRITE ${CMAKE_BINARY_DIR}/version.cmake
     "execute_process(
         COMMAND ${GIT_EXECUTABLE} describe --tags --dirty=-dirty
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        WORKING_DIRECTORY \"${CMAKE_SOURCE_DIR}\"
         RESULT_VARIABLE
         res
         OUTPUT_VARIABLE

--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -1,5 +1,13 @@
 # Changes                                               {#changes}
 
+## v1.0.8
+
+Commit  | Description
+------- | -----------
+b74024d | Added support for paths with spaces in the build system
+d76117a | Remove support for 32-bit builds
+27c1942 | IPA-4778: Fixed issues found by coverity
+ad8cac0 | Updated the documentation
 
 ## v1.0.7
 

--- a/interop/logic/plot/plot_by_cycle.h
+++ b/interop/logic/plot/plot_by_cycle.h
@@ -313,6 +313,7 @@ namespace illumina { namespace interop { namespace logic { namespace plot
                        model::plot::plot_data<Point>& data)
                         throw(model::index_out_of_bounds_exception,
                         model::invalid_filter_option,
+                        model::invalid_channel_exception,
                         model::invalid_metric_type)
     {
         const constants::metric_type type = constants::parse<constants::metric_type>(metric_name);


### PR DESCRIPTION
Found a bug when building on Windows

Also fixed an issue discovered by Coverity.