### PR TITLE
Bug fixes q metric summary

### DIFF
--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -1,5 +1,16 @@
 # Changes                                               {#changes}
 
+## v1.0.10
+
+Date       | Description
+---------- | -----------
+2016-09-01 | Bug fix clearing the summary stat prior to setting it
+2016-09-01 | Fixed a bug in QMetrics V6 Unbinned, added unit test and C# example
+2016-08-31 | IPA-5069: Flush out on demand loading further for each tab
+2016-08-30 | Various minor fixes to get public working with Clang3.4 and MSVC12
+2016-08-30 | Bug fix to RunInfo section validation
+2016-08-30 | IPA-5069: Support on demand loading for SAV (Part 1)
+2016-08-26 | IPA-5028: Add RunInfo and InterOp validation
 
 ## v1.0.9
 

--- a/interop/io/metric_stream.h
+++ b/interop/io/metric_stream.h
@@ -166,7 +166,8 @@ namespace illumina { namespace interop { namespace io
                 }
                 if (count != record_size)
                 {
-                    INTEROP_THROW(bad_format_exception, "Record does not match expected size!");
+                    INTEROP_THROW(bad_format_exception, "Record does not match expected size: "
+                            << count << " != " << record_size);
                 }
                 if (metric.lane() > 0 && (metric_t::CHECK_TILE_ID == 0 || metric.tile() > 0))
                 {

--- a/interop/logic/plot/plot_by_cycle.h
+++ b/interop/logic/plot/plot_by_cycle.h
@@ -32,7 +32,19 @@ namespace illumina { namespace interop { namespace logic { namespace plot
                     model::invalid_filter_option,
                     model::invalid_read_exception);
 
-
+    /** List the required on demand metrics
+     *
+     * @param type specific metric value to plot by cycle
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_plot_by_cycle_metrics(const constants::metric_type type, std::vector<unsigned char>& valid_to_load);
+    /** List the required on demand metrics
+     *
+     * @param metric_name name of metric value to plot by cycle
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_plot_by_cycle_metrics(const std::string& metric_name, std::vector<unsigned char>& valid_to_load)
+    throw(model::invalid_metric_type);
 
     /** Plot a specified metric value by cycle using the candle stick model
      *

--- a/interop/logic/plot/plot_by_cycle.h
+++ b/interop/logic/plot/plot_by_cycle.h
@@ -11,6 +11,7 @@
 #include "interop/model/plot/plot_data.h"
 #include "interop/model/plot/candle_stick_point.h"
 #include "interop/constants/enums.h"
+#include "interop/logic/utils/metrics_to_load.h"
 
 namespace illumina { namespace interop { namespace logic { namespace plot
 {
@@ -31,20 +32,6 @@ namespace illumina { namespace interop { namespace logic { namespace plot
                     model::invalid_channel_exception,
                     model::invalid_filter_option,
                     model::invalid_read_exception);
-
-    /** List the required on demand metrics
-     *
-     * @param type specific metric value to plot by cycle
-     * @param valid_to_load list of metrics to load on demand
-     */
-    void list_plot_by_cycle_metrics(const constants::metric_type type, std::vector<unsigned char>& valid_to_load);
-    /** List the required on demand metrics
-     *
-     * @param metric_name name of metric value to plot by cycle
-     * @param valid_to_load list of metrics to load on demand
-     */
-    void list_plot_by_cycle_metrics(const std::string& metric_name, std::vector<unsigned char>& valid_to_load)
-    throw(model::invalid_metric_type);
 
     /** Plot a specified metric value by cycle using the candle stick model
      *
@@ -76,4 +63,5 @@ namespace illumina { namespace interop { namespace logic { namespace plot
      * @param ignore_accumulated if true, ignore accumulated Q20 and Q30
      */
     void list_by_cycle_metrics(std::vector<std::string>& names, const bool ignore_accumulated=false);
+
 }}}}

--- a/interop/logic/plot/plot_by_lane.h
+++ b/interop/logic/plot/plot_by_lane.h
@@ -12,6 +12,7 @@
 #include "interop/model/plot/filter_options.h"
 #include "interop/model/plot/plot_data.h"
 #include "interop/model/plot/candle_stick_point.h"
+#include "interop/logic/utils/metrics_to_load.h"
 
 namespace illumina { namespace interop { namespace logic { namespace plot
 {
@@ -61,5 +62,6 @@ namespace illumina { namespace interop { namespace logic { namespace plot
      * @param ignore_pf if true, ignore density PF and cluster PF
      */
     void list_by_lane_metrics(std::vector<std::string>& names, const bool ignore_pf=false);
+
 
 }}}}

--- a/interop/logic/plot/plot_data.h
+++ b/interop/logic/plot/plot_data.h
@@ -10,93 +10,98 @@
 #include <limits>
 #include "interop/model/plot/plot_data.h"
 
-namespace illumina { namespace interop { namespace logic { namespace plot {
-
-/** Logic for auto scaling both axes of plot data
- *
- * @param data model for plot data
- * @param zero_min if true, set minimum to 0
- * @param scale_y_max factor to scale maximum Y value
- */
-template<typename Point>
-void auto_scale(model::plot::plot_data<Point>& data, const bool zero_min=true, const float scale_y_max=1.1f)
+namespace illumina { namespace interop { namespace logic { namespace plot
 {
-    typedef typename model::plot::plot_data<Point>::const_iterator const_series_iterator;
-    typedef typename model::plot::series<Point>::const_iterator const_point_iterator;
-    float ymin = std::numeric_limits<float>::max();
-    float xmin = std::numeric_limits<float>::max();
-    float ymax = -std::numeric_limits<float>::max();
-    float xmax = -std::numeric_limits<float>::max();
-    for(const_series_iterator cur_series = data.begin(), series_end = data.end();cur_series != series_end;++cur_series)
+
+    /** Logic for auto scaling both axes of plot data
+     *
+     * @param data model for plot data
+     * @param zero_min if true, set minimum to 0
+     * @param scale_y_max factor to scale maximum Y value
+     */
+    template<typename Point>
+    void auto_scale(model::plot::plot_data <Point> &data, const bool zero_min = true, const float scale_y_max = 1.1f)
     {
-        for(const_point_iterator cur_pt = cur_series->begin(), end_pt = cur_series->end();cur_pt != end_pt;++cur_pt)
+        typedef typename model::plot::plot_data<Point>::const_iterator const_series_iterator;
+        typedef typename model::plot::series<Point>::const_iterator const_point_iterator;
+        float ymin = std::numeric_limits<float>::max();
+        float xmin = std::numeric_limits<float>::max();
+        float ymax = -std::numeric_limits<float>::max();
+        float xmax = -std::numeric_limits<float>::max();
+        for (const_series_iterator cur_series = data.begin(), series_end = data.end();
+             cur_series != series_end; ++cur_series)
         {
-            ymax = std::max(ymax, cur_pt->max_value());
-            xmax = std::max(xmax, cur_pt->x());
-            if(zero_min) continue;
-            ymin = std::min(ymin, cur_pt->min_value());
-            xmin = std::min(xmin, cur_pt->x());
+            for (const_point_iterator cur_pt = cur_series->begin(), end_pt = cur_series->end();
+                 cur_pt != end_pt; ++cur_pt)
+            {
+                ymax = std::max(ymax, cur_pt->max_value());
+                xmax = std::max(xmax, cur_pt->x());
+                if (zero_min) continue;
+                ymin = std::min(ymin, cur_pt->min_value());
+                xmin = std::min(xmin, cur_pt->x());
+            }
         }
+        if (ymin == std::numeric_limits<float>::max()) ymin = 0;
+        if (xmin == std::numeric_limits<float>::max()) xmin = 0;
+        ymax = (ymax == -std::numeric_limits<float>::max()) ? 0 : scale_y_max * ymax + 0.0001f;
+        if (xmax == -std::numeric_limits<float>::max()) xmax = 0;
+        data.set_range(xmin, xmax, ymin, ymax);
     }
-    if(ymin == std::numeric_limits<float>::max()) ymin = 0;
-    if(xmin == std::numeric_limits<float>::max()) xmin = 0;
-    ymax = (ymax == -std::numeric_limits<float>::max()) ? 0 : scale_y_max * ymax + 0.0001f;
-    if(xmax == -std::numeric_limits<float>::max()) xmax = 0;
-    data.set_range(xmin, xmax, ymin, ymax);
-}
 
-/** Logic for auto scaling the x-axis of plot data
- *
- * @param data model for plot data
- * @param zero_min if true, set minimum to 0
- */
-template<typename Point>
-void auto_scale_x(model::plot::plot_data<Point>& data, const bool zero_min=true)
-{
-    typedef typename model::plot::plot_data<Point>::const_iterator const_series_iterator;
-    typedef typename model::plot::series<Point>::const_iterator const_point_iterator;
-    float xmin = std::numeric_limits<float>::max();
-    float xmax = -std::numeric_limits<float>::max();
-    for(const_series_iterator cur_series = data.begin(), series_end = data.end();cur_series != series_end;++cur_series)
+    /** Logic for auto scaling the x-axis of plot data
+     *
+     * @param data model for plot data
+     * @param zero_min if true, set minimum to 0
+     */
+    template<typename Point>
+    void auto_scale_x(model::plot::plot_data <Point> &data, const bool zero_min = true)
     {
-        for(const_point_iterator cur_pt = cur_series->begin(), end_pt = cur_series->end();cur_pt != end_pt;++cur_pt)
+        typedef typename model::plot::plot_data<Point>::const_iterator const_series_iterator;
+        typedef typename model::plot::series<Point>::const_iterator const_point_iterator;
+        float xmin = std::numeric_limits<float>::max();
+        float xmax = -std::numeric_limits<float>::max();
+        for (const_series_iterator cur_series = data.begin(), series_end = data.end();
+             cur_series != series_end; ++cur_series)
         {
-            xmax = std::max(xmax, cur_pt->x());
-            if(zero_min) continue;
-            xmin = std::min(xmin, cur_pt->x());
+            for (const_point_iterator cur_pt = cur_series->begin(), end_pt = cur_series->end();
+                 cur_pt != end_pt; ++cur_pt)
+            {
+                xmax = std::max(xmax, cur_pt->x());
+                if (zero_min) continue;
+                xmin = std::min(xmin, cur_pt->x());
+            }
         }
+        if (xmin == std::numeric_limits<float>::max()) xmin = 0;
+        if (xmax == -std::numeric_limits<float>::max()) xmax = 0;
+        data.set_xrange(xmin, xmax);
     }
-    if(xmin == std::numeric_limits<float>::max()) xmin = 0;
-    if(xmax == -std::numeric_limits<float>::max()) xmax = 0;
-    data.set_xrange(xmin, xmax);
-}
 
-/** Logic for auto scaling the y-axis of plot data
- *
- * @param data model for plot data
- * @param zero_min if true, set minimum to 0
- * @param scale_y_max factor to scale maximum Y value
- */
-template<typename Point>
-void auto_scale_y(model::plot::plot_data<Point>& data, const bool zero_min=true, const float scale_y_max=1.1f)
-{
-    typedef typename model::plot::plot_data<Point>::const_iterator const_series_iterator;
-    typedef typename model::plot::series<Point>::const_iterator const_point_iterator;
-    float ymin = std::numeric_limits<float>::max();
-    float ymax = -std::numeric_limits<float>::max();
-    for(const_series_iterator cur_series = data.begin(), series_end = data.end();cur_series != series_end;++cur_series)
+    /** Logic for auto scaling the y-axis of plot data
+     *
+     * @param data model for plot data
+     * @param zero_min if true, set minimum to 0
+     * @param scale_y_max factor to scale maximum Y value
+     */
+    template<typename Point>
+    void auto_scale_y(model::plot::plot_data <Point> &data, const bool zero_min = true, const float scale_y_max = 1.1f)
     {
-        for(const_point_iterator cur_pt = cur_series->begin(), end_pt = cur_series->end();cur_pt != end_pt;++cur_pt)
+        typedef typename model::plot::plot_data<Point>::const_iterator const_series_iterator;
+        typedef typename model::plot::series<Point>::const_iterator const_point_iterator;
+        float ymin = std::numeric_limits<float>::max();
+        float ymax = -std::numeric_limits<float>::max();
+        for (const_series_iterator cur_series = data.begin(), series_end = data.end();
+             cur_series != series_end; ++cur_series)
         {
-            ymax = std::max(ymax, cur_pt->max_value());
-            if(zero_min) continue;
-            ymin = std::min(ymin, cur_pt->min_value());
+            for (const_point_iterator cur_pt = cur_series->begin(), end_pt = cur_series->end();
+                 cur_pt != end_pt; ++cur_pt)
+            {
+                ymax = std::max(ymax, cur_pt->max_value());
+                if (zero_min) continue;
+                ymin = std::min(ymin, cur_pt->min_value());
+            }
         }
+        if (ymin == std::numeric_limits<float>::max()) ymin = 0;
+        ymax = (ymax == -std::numeric_limits<float>::max()) ? 0 : scale_y_max * ymax + 0.0001f;
+        data.set_yrange(ymin, ymax);
     }
-    if(ymin == std::numeric_limits<float>::max()) ymin = 0;
-    ymax = (ymax == -std::numeric_limits<float>::max()) ? 0 : scale_y_max * ymax + 0.0001f;
-    data.set_yrange(ymin, ymax);
-}
-
-
 }}}}

--- a/interop/logic/plot/plot_flowcell_map.h
+++ b/interop/logic/plot/plot_flowcell_map.h
@@ -11,6 +11,7 @@
 #include "interop/model/run_metrics.h"
 #include "interop/model/plot/filter_options.h"
 #include "interop/model/plot/flowcell_data.h"
+#include "interop/logic/utils/metrics_to_load.h"
 
 namespace illumina { namespace interop { namespace logic { namespace plot
 {

--- a/interop/logic/plot/plot_qscore_heatmap.h
+++ b/interop/logic/plot/plot_qscore_heatmap.h
@@ -10,6 +10,7 @@
 #include "interop/model/run_metrics.h"
 #include "interop/model/plot/filter_options.h"
 #include "interop/model/plot/heatmap_data.h"
+#include "interop/logic/utils/metrics_to_load.h"
 
 namespace illumina { namespace interop { namespace logic { namespace plot
 {

--- a/interop/logic/plot/plot_qscore_histogram.h
+++ b/interop/logic/plot/plot_qscore_histogram.h
@@ -10,6 +10,7 @@
 #include "interop/model/plot/filter_options.h"
 #include "interop/model/plot/bar_point.h"
 #include "interop/logic/plot/plot_data.h"
+#include "interop/logic/utils/metrics_to_load.h"
 
 namespace illumina { namespace interop { namespace logic { namespace plot {
 

--- a/interop/logic/plot/plot_sample_qc.h
+++ b/interop/logic/plot/plot_sample_qc.h
@@ -10,6 +10,7 @@
 #include "interop/model/run_metrics.h"
 #include "interop/model/plot/bar_point.h"
 #include "interop/logic/plot/plot_data.h"
+#include "interop/logic/utils/metrics_to_load.h"
 
 namespace illumina { namespace interop { namespace logic { namespace plot
 {

--- a/interop/logic/summary/index_summary.h
+++ b/interop/logic/summary/index_summary.h
@@ -9,6 +9,7 @@
 #include "interop/model/model_exceptions.h"
 #include "interop/model/summary/index_flowcell_summary.h"
 #include "interop/model/run_metrics.h"
+#include "interop/logic/utils/metrics_to_load.h"
 
 
 namespace illumina { namespace interop { namespace logic { namespace summary
@@ -47,6 +48,4 @@ namespace illumina { namespace interop { namespace logic { namespace summary
     void summarize_index_metrics(const model::metrics::run_metrics &metrics,
                                         model::summary::index_flowcell_summary &summary)
                                             throw(model::index_out_of_bounds_exception);
-
-
 }}}}

--- a/interop/logic/summary/run_summary.h
+++ b/interop/logic/summary/run_summary.h
@@ -9,6 +9,7 @@
 #include "interop/model/model_exceptions.h"
 #include "interop/model/summary/run_summary.h"
 #include "interop/model/run_metrics.h"
+#include "interop/logic/utils/metrics_to_load.h"
 
 
 namespace illumina { namespace interop { namespace logic { namespace summary
@@ -24,5 +25,6 @@ namespace illumina { namespace interop { namespace logic { namespace summary
      */
     void summarize_run_metrics(model::metrics::run_metrics& metrics, model::summary::run_summary& summary)
     throw( model::index_out_of_bounds_exception, model::invalid_channel_exception );
+
 
 }}}}

--- a/interop/logic/summary/summary_statistics.h
+++ b/interop/logic/summary/summary_statistics.h
@@ -167,6 +167,7 @@ namespace illumina { namespace interop { namespace logic { namespace summary
     template<typename I, typename S, typename BinaryOp, typename Compare>
     size_t nan_summarize(I beg, I end, S &stat, BinaryOp op, Compare comp)
     {
+        stat.clear();
         if (beg == end) return 0;
         end = util::remove_nan(beg, end, op);
         if (beg == end) return 0;

--- a/interop/logic/table/create_imaging_table.h
+++ b/interop/logic/table/create_imaging_table.h
@@ -50,6 +50,6 @@ namespace illumina { namespace interop { namespace logic { namespace table
      *
      * @param valid_to_load list of metrics to load on demand
      */
-    void list_imaging_table_metrics(std::vector<unsigned char>& valid_to_load);
+    void list_imaging_table_metrics_to_load(std::vector<unsigned char>& valid_to_load);
 
 }}}}

--- a/interop/logic/table/create_imaging_table.h
+++ b/interop/logic/table/create_imaging_table.h
@@ -46,4 +46,10 @@ namespace illumina { namespace interop { namespace logic { namespace table
     void create_imaging_table(const model::metrics::run_metrics& metrics, model::table::imaging_table& table)
     throw(model::invalid_column_type, model::index_out_of_bounds_exception);
 
+    /** List the required on demand metrics
+     *
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_imaging_table_metrics(std::vector<unsigned char>& valid_to_load);
+
 }}}}

--- a/interop/logic/utils/metrics_to_load.h
+++ b/interop/logic/utils/metrics_to_load.h
@@ -1,0 +1,75 @@
+/** Collection of utilities for metric listing
+ *
+ *  @file
+ *  @date  4/28/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#pragma once
+#include <vector>
+#include "interop/constants/enums.h"
+#include "interop/model/model_exceptions.h"
+
+namespace illumina { namespace interop { namespace logic { namespace utils
+{
+    /** List the required on demand metrics
+     *
+     * @param group specific metric group to load
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_metrics_to_load(const constants::metric_group group, std::vector<unsigned char>& valid_to_load);
+    /** List the required on demand metrics
+     *
+     * @param type specific metric type to load
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_metrics_to_load(const constants::metric_type type, std::vector<unsigned char>& valid_to_load);
+    /** List the required on demand metrics
+     *
+     * @param groups collection of specific metric groups to load
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_metrics_to_load(const std::vector<constants::metric_group>& groups,
+                              std::vector<unsigned char>& valid_to_load);
+    /** List the required on demand metrics
+     *
+     * @param types collection of specific metric types to load
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_metrics_to_load(const std::vector<constants::metric_type>& types,
+                              std::vector<unsigned char>& valid_to_load);
+    /** List the required on demand metrics
+     *
+     * @param metric_name name of metric value to load
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_metrics_to_load(const std::string& metric_name, std::vector<unsigned char>& valid_to_load)
+    throw(model::invalid_metric_type);
+
+    /** List all required metric groups
+     *
+     * @param groups destination group list
+     */
+    void list_summary_metric_groups(std::vector<constants::metric_group>& groups);
+
+    /** List all required metric groups
+     *
+     * @param groups destination group list
+     */
+    void list_index_summary_metric_groups(std::vector<constants::metric_group>& groups);
+
+
+    /** List all required metric groups
+     *
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_summary_metrics_to_load(std::vector<unsigned char>& valid_to_load);
+
+    /** List all required metric groups
+     *
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_index_metrics_to_load(std::vector<unsigned char>& valid_to_load);
+
+
+}}}}

--- a/interop/model/run_metrics.h
+++ b/interop/model/run_metrics.h
@@ -131,6 +131,25 @@ namespace illumina { namespace interop { namespace model { namespace metrics
         model::index_out_of_bounds_exception,
         model::invalid_tile_naming_method,
         model::invalid_run_info_exception);
+        /** Read binary metrics and XML files from the run folder
+         *
+         * @param run_folder run folder path
+         * @param valid_to_load list of metrics to load
+         */
+        void read(const std::string &run_folder, const std::vector<unsigned char>& valid_to_load)
+        throw(xml::xml_file_not_found_exception,
+        xml::bad_xml_format_exception,
+        xml::empty_xml_format_exception,
+        xml::missing_xml_element_exception,
+        xml::xml_parse_exception,
+        io::file_not_found_exception,
+        io::bad_format_exception,
+        io::incomplete_file_exception,
+        io::format_exception,
+        model::index_out_of_bounds_exception,
+        model::invalid_tile_naming_method,
+        model::invalid_run_info_exception,
+        invalid_parameter);
 
         /** Read XML files: RunInfo.xml and possibly RunParameters.xml
          *
@@ -453,6 +472,37 @@ namespace illumina { namespace interop { namespace model { namespace metrics
         io::file_not_found_exception,
         io::bad_format_exception,
         io::incomplete_file_exception);
+        /** Read binary metrics from the run folder
+         *
+         * This function ignores:
+         *  - Missing InterOp files
+         *  - Incomplete InterOp files
+         *  - Missing RunParameters.xml for non-legacy run folders
+         *
+         * @param run_folder run folder path
+         * @param valid_to_load list of metrics to load
+         * @param n number of elements in valid_to_load
+         */
+        void read_metrics(const std::string &run_folder, const unsigned char* valid_to_load, const size_t n) throw(
+        io::file_not_found_exception,
+        io::bad_format_exception,
+        io::incomplete_file_exception,
+        invalid_parameter);
+        /** Read binary metrics from the run folder
+         *
+         * This function ignores:
+         *  - Missing InterOp files
+         *  - Incomplete InterOp files
+         *  - Missing RunParameters.xml for non-legacy run folders
+         *
+         * @param run_folder run folder path
+         * @param valid_to_load list of metrics to load
+         */
+        void read_metrics(const std::string &run_folder, const std::vector<unsigned char>& valid_to_load) throw(
+        io::file_not_found_exception,
+        io::bad_format_exception,
+        io::incomplete_file_exception,
+        invalid_parameter);
         /** Write binary metrics to the run folder
          *
          * @param run_folder run folder path

--- a/interop/model/summary/metric_stat.h
+++ b/interop/model/summary/metric_stat.h
@@ -33,6 +33,16 @@ namespace illumina { namespace interop { namespace model { namespace summary
         }
 
     public:
+        /** Clear the stat variables
+         */
+        void clear()
+        {
+            m_mean = 0;
+            m_stddev = 0;
+            m_median = 0;
+        }
+
+    public:
         /** Set the mean value
          *
          * @param val mean value

--- a/src/apps/imaging_table.cpp
+++ b/src/apps/imaging_table.cpp
@@ -41,12 +41,12 @@ int main(int argc, char** argv)
 
     std::cout << "# Version: " << INTEROP_VERSION << std::endl;
 
+    std::vector<unsigned char> valid_to_load;
+    logic::table::list_imaging_table_metrics_to_load(valid_to_load);
     for (int i = 1; i < argc; i++)
     {
         run_metrics run;
         std::cout << "# Run Folder: " << io::basename(argv[i]) << std::endl;
-        std::vector<unsigned char> valid_to_load;
-        logic::table::list_imaging_table_metrics(valid_to_load);
         int ret = read_run_metrics(argv[i], run,valid_to_load);
         if (ret != SUCCESS) return ret;
         model::table::imaging_table table;

--- a/src/apps/imaging_table.cpp
+++ b/src/apps/imaging_table.cpp
@@ -45,7 +45,9 @@ int main(int argc, char** argv)
     {
         run_metrics run;
         std::cout << "# Run Folder: " << io::basename(argv[i]) << std::endl;
-        int ret = read_run_metrics(argv[i], run);
+        std::vector<unsigned char> valid_to_load;
+        logic::table::list_imaging_table_metrics(valid_to_load);
+        int ret = read_run_metrics(argv[i], run,valid_to_load);
         if (ret != SUCCESS) return ret;
         model::table::imaging_table table;
         try

--- a/src/apps/inc/application.h
+++ b/src/apps/inc/application.h
@@ -74,3 +74,49 @@ inline int read_run_metrics(const char* filename, illumina::interop::model::metr
     }
     return SUCCESS;
 }
+/** Read run metrics from the given filename
+ *
+ * This function handles many error conditions.
+ *
+ * @param filename run folder containing RunInfo.xml and InterOps
+ * @param metrics run metrics
+ * @param valid_to_load list of metrics that are valid to load
+ * @return exit code
+ */
+inline int read_run_metrics(const char* filename,
+                            illumina::interop::model::metrics::run_metrics& metrics,
+                            const std::vector<unsigned char>& valid_to_load)
+{
+    using namespace illumina::interop;
+    using namespace illumina::interop::model;
+    try
+    {
+        metrics.read(filename, valid_to_load);
+    }
+    catch(const xml::xml_file_not_found_exception& ex)
+    {
+        std::cerr << ex.what() << std::endl;
+        return MISSING_RUNINFO_XML;
+    }
+    catch(const xml::xml_parse_exception& ex)
+    {
+        std::cerr << ex.what() << std::endl;
+        return MALFORMED_XML;
+    }
+    catch(const io::bad_format_exception& ex)
+    {
+        std::cerr << ex.what() << std::endl;
+        return BAD_FORMAT;
+    }
+    catch(const std::exception& ex)
+    {
+        std::cerr << ex.what() << std::endl;
+        return UNEXPECTED_EXCEPTION;
+    }
+    if(metrics.empty())
+    {
+        std::cerr << "No InterOp files found" << std::endl;
+        return EMPTY_INTEROP;
+    }
+    return SUCCESS;
+}

--- a/src/apps/index_summary.cpp
+++ b/src/apps/index_summary.cpp
@@ -72,11 +72,13 @@ int main(int argc, char** argv)
         return INVALID_ARGUMENTS;
     }
 
+    std::vector<unsigned char> valid_to_load;
+    logic::utils::list_index_metrics_to_load(valid_to_load); // Only load the InterOp files required
     std::cout << "# Version: " << INTEROP_VERSION << std::endl;
     for(int i=1;i<argc;i++)
     {
         run_metrics run;
-        int ret = read_run_metrics(argv[i], run);
+        int ret = read_run_metrics(argv[i], run, valid_to_load);
         if (ret != SUCCESS) return ret;
         index_flowcell_summary summary;
         try

--- a/src/apps/plot_by_cycle.cpp
+++ b/src/apps/plot_by_cycle.cpp
@@ -102,7 +102,9 @@ int main(int argc, const char** argv)
         run_metrics run;
         const std::string run_name = io::basename(argv[i]);
         std::cout << "# Run Folder: " << run_name << std::endl;
-        int ret = read_run_metrics(argv[i], run);
+        std::vector<unsigned char> valid_to_load;
+        logic::plot::list_plot_by_cycle_metrics(metric_name, valid_to_load); // Only load the InterOp files required
+        int ret = read_run_metrics(argv[i], run, valid_to_load);
         if(ret != SUCCESS) return ret;
 
         /*if(1 == 1)

--- a/src/apps/plot_by_cycle.cpp
+++ b/src/apps/plot_by_cycle.cpp
@@ -97,7 +97,15 @@ int main(int argc, const char** argv)
         return INVALID_ARGUMENTS;
     }
     std::vector<unsigned char> valid_to_load;
-    logic::utils::list_metrics_to_load(metric_name, valid_to_load); // Only load the InterOp files required
+    try
+    {
+        logic::utils::list_metrics_to_load(metric_name, valid_to_load); // Only load the InterOp files required
+    }
+    catch(const std::exception& ex)
+    {
+        std::cerr << ex.what() << std::endl;
+        return INVALID_ARGUMENTS;
+    }
 
     for(int i=1;i<argc;i++)
     {

--- a/src/apps/plot_by_cycle.cpp
+++ b/src/apps/plot_by_cycle.cpp
@@ -96,14 +96,14 @@ int main(int argc, const char** argv)
         std::cerr << ex.what() << std::endl;
         return INVALID_ARGUMENTS;
     }
+    std::vector<unsigned char> valid_to_load;
+    logic::utils::list_metrics_to_load(metric_name, valid_to_load); // Only load the InterOp files required
 
     for(int i=1;i<argc;i++)
     {
         run_metrics run;
         const std::string run_name = io::basename(argv[i]);
         std::cout << "# Run Folder: " << run_name << std::endl;
-        std::vector<unsigned char> valid_to_load;
-        logic::plot::list_plot_by_cycle_metrics(metric_name, valid_to_load); // Only load the InterOp files required
         int ret = read_run_metrics(argv[i], run, valid_to_load);
         if(ret != SUCCESS) return ret;
 

--- a/src/apps/plot_by_lane.cpp
+++ b/src/apps/plot_by_lane.cpp
@@ -94,7 +94,14 @@ int main(int argc, const char** argv)
         return INVALID_ARGUMENTS;
     }
     std::vector<unsigned char> valid_to_load;
-    logic::utils::list_metrics_to_load(metric_name, valid_to_load); // Only load the InterOp files required
+    try{
+        logic::utils::list_metrics_to_load(metric_name, valid_to_load); // Only load the InterOp files required
+    }
+    catch(const std::exception& ex)
+    {
+        std::cerr << ex.what() << std::endl;
+        return INVALID_ARGUMENTS;
+    }
 
     for(int i=1;i<argc;i++)
     {

--- a/src/apps/plot_by_lane.cpp
+++ b/src/apps/plot_by_lane.cpp
@@ -93,6 +93,8 @@ int main(int argc, const char** argv)
         std::cerr << ex.what() << std::endl;
         return INVALID_ARGUMENTS;
     }
+    std::vector<unsigned char> valid_to_load;
+    logic::utils::list_metrics_to_load(metric_name, valid_to_load); // Only load the InterOp files required
 
     for(int i=1;i<argc;i++)
     {
@@ -100,7 +102,7 @@ int main(int argc, const char** argv)
 
         const std::string run_name = io::basename(argv[i]);
         std::cout << "# Run Folder: " << run_name << std::endl;
-        int ret = read_run_metrics(argv[i], run);
+        int ret = read_run_metrics(argv[i], run, valid_to_load);
         if(ret != SUCCESS) return ret;
 
         options.tile_naming_method(run.run_info().flowcell().naming_method());

--- a/src/apps/plot_flowcell.cpp
+++ b/src/apps/plot_flowcell.cpp
@@ -112,7 +112,15 @@ int main(int argc, const char** argv)
         return INVALID_ARGUMENTS;
     }
     std::vector<unsigned char> valid_to_load;
-    logic::utils::list_metrics_to_load(metric_name, valid_to_load); // Only load the InterOp files required
+
+    try{
+        logic::utils::list_metrics_to_load(metric_name, valid_to_load); // Only load the InterOp files required
+    }
+    catch(const std::exception& ex)
+    {
+        std::cerr << ex.what() << std::endl;
+        return INVALID_ARGUMENTS;
+    }
 
     for(int i=1;i<argc;i++)
     {

--- a/src/apps/plot_flowcell.cpp
+++ b/src/apps/plot_flowcell.cpp
@@ -111,6 +111,8 @@ int main(int argc, const char** argv)
         std::cerr << ex.what() << std::endl;
         return INVALID_ARGUMENTS;
     }
+    std::vector<unsigned char> valid_to_load;
+    logic::utils::list_metrics_to_load(metric_name, valid_to_load); // Only load the InterOp files required
 
     for(int i=1;i<argc;i++)
     {
@@ -118,7 +120,7 @@ int main(int argc, const char** argv)
 
         const std::string run_name = io::basename(argv[i]);
         std::cout << "# Run Folder: " << run_name << std::endl;
-        int ret = read_run_metrics(argv[i], run);
+        int ret = read_run_metrics(argv[i], run, valid_to_load);
         if(ret != SUCCESS) return ret;
 
         options.tile_naming_method(run.run_info().flowcell().naming_method());

--- a/src/apps/plot_qscore_heatmap.cpp
+++ b/src/apps/plot_qscore_heatmap.cpp
@@ -87,6 +87,8 @@ int main(int argc, const char** argv)
         std::cerr << ex.what() << std::endl;
         return INVALID_ARGUMENTS;
     }
+    std::vector<unsigned char> valid_to_load;
+    logic::utils::list_metrics_to_load(constants::Q, valid_to_load); // Only load the InterOp files required
 
     for(int i=1;i<argc;i++)
     {
@@ -94,7 +96,7 @@ int main(int argc, const char** argv)
 
         const std::string run_name = io::basename(argv[i]);
         std::cout << "# Run Folder: " << run_name << std::endl;
-        int ret = read_run_metrics(argv[i], run);
+        int ret = read_run_metrics(argv[i], run, valid_to_load);
         if(ret != SUCCESS) return ret;
 
 

--- a/src/apps/plot_qscore_histogram.cpp
+++ b/src/apps/plot_qscore_histogram.cpp
@@ -93,6 +93,8 @@ int main(int argc, const char** argv)
         std::cerr << ex.what() << std::endl;
         return INVALID_ARGUMENTS;
     }
+    std::vector<unsigned char> valid_to_load;
+    logic::utils::list_metrics_to_load(constants::Q, valid_to_load); // Only load the InterOp files required
 
     for(int i=1;i<argc;i++)
     {
@@ -100,7 +102,7 @@ int main(int argc, const char** argv)
 
         const std::string run_name = io::basename(argv[i]);
         std::cout << "# Run Folder: " << run_name << std::endl;
-        int ret = read_run_metrics(argv[i], run);
+        int ret = read_run_metrics(argv[i], run, valid_to_load);
         if(ret != SUCCESS) return ret;
 
         options.tile_naming_method(run.run_info().flowcell().naming_method());

--- a/src/apps/plot_sample_qc.cpp
+++ b/src/apps/plot_sample_qc.cpp
@@ -53,13 +53,15 @@ int main(int argc, char** argv)
 
     std::cout << "# Version: " << INTEROP_VERSION << std::endl;
 
+    std::vector<unsigned char> valid_to_load;
+    logic::utils::list_index_metrics_to_load(valid_to_load); // Only load the InterOp files required
     for(int i=1;i<argc;i++)
     {
         run_metrics run;
 
         const std::string run_name = io::basename(argv[i]);
         std::cout << "# Run Folder: " << run_name << std::endl;
-        int ret = read_run_metrics(argv[i], run);
+        int ret = read_run_metrics(argv[i], run, valid_to_load);
         if(ret != SUCCESS) return ret;
 
         model::plot::plot_data<model::plot::bar_point> data;

--- a/src/apps/summary.cpp
+++ b/src/apps/summary.cpp
@@ -63,12 +63,15 @@ int main(int argc, char** argv)
         return INVALID_ARGUMENTS;
     }
 
+    std::vector<unsigned char> valid_to_load;
+    logic::utils::list_summary_metrics_to_load(valid_to_load); // Only load the InterOp files required
+
     std::cout << "# Version: " << INTEROP_VERSION << std::endl;
     for(int i=1;i<argc;i++)
     {
         run_metrics run;
 
-        int ret = read_run_metrics(argv[i], run);
+        int ret = read_run_metrics(argv[i], run, valid_to_load);
         if(ret != SUCCESS) return ret;
         run_summary summary;
         try

--- a/src/examples/csharp/CMakeLists.txt
+++ b/src/examples/csharp/CMakeLists.txt
@@ -56,4 +56,5 @@ endfunction()
 add_csharp_example(csharp_example1 Example1.cs)
 add_csharp_example(csharp_example2 Example2.cs)
 add_csharp_example(csharp_example3 Example3.cs)
+add_csharp_example(csharp_summary SummaryExample.cs)
 

--- a/src/examples/csharp/SummaryExample.cs
+++ b/src/examples/csharp/SummaryExample.cs
@@ -1,0 +1,34 @@
+
+// @ [Create Summary Model from Run Folder]
+using System;
+using Illumina.InterOp.Run;
+using Illumina.InterOp.Metrics;
+using Illumina.InterOp.Comm;
+using Illumina.InterOp.Summary;
+
+class SummaryExample
+{
+	static int Main(string[] args)
+	{
+		if (args.Length != 1)
+		{
+			if (args.Length < 1)
+				Console.WriteLine ("No run folder");
+			else
+				Console.WriteLine ("Too many arguments");
+			return 1;
+		}
+
+		run_metrics metrics = new run_metrics();
+		metrics.read(args[0]);
+
+
+        run_summary summary = new run_summary();
+        c_csharp_summary.summarize_run_metrics(metrics, summary);
+
+
+		Console.WriteLine("Yield: {0}", summary.total_summary().yield_g());
+		return 0;
+	}
+}
+// @ [Reading a binary InterOp file in CSharp]

--- a/src/ext/swig/arrays/arrays_csharp_impl.i
+++ b/src/ext/swig/arrays/arrays_csharp_impl.i
@@ -124,6 +124,7 @@ CSHARP_ARRAYS_FIXED2(float, float)
 
 %apply float FIXED[] {float *}
 
+%apply byte {unsigned char};
 
 
 

--- a/src/ext/swig/metrics.i
+++ b/src/ext/swig/metrics.i
@@ -126,6 +126,7 @@ WRAP_METRICS(IMPORT_METRIC_WRAPPER)
 %template(uint_vector) std::vector< uint32_t >;
 %template(float_vector) std::vector< float >;
 %template(bool_vector) std::vector< bool >;
+%template(uchar_vector) std::vector< uint8_t >;
 %template(tile_metric_map) std::map< uint64_t, illumina::interop::model::metric_base::base_metric >;
 %template(cycle_metric_map) std::map< uint64_t, illumina::interop::model::metric_base::base_cycle_metric >;
 %template(read_metric_vector) std::vector< illumina::interop::model::metrics::read_metric >;

--- a/src/ext/swig/metrics.i
+++ b/src/ext/swig/metrics.i
@@ -169,12 +169,14 @@ WRAP_METRICS(WRAP_METRIC_SET)
 #include "interop/logic/metric/q_metric.h"
 #include "interop/model/run_metrics.h"
 #include "interop/logic/utils/metric_type_ext.h"
+#include "interop/logic/utils/metrics_to_load.h"
 %}
 
 %include "interop/logic/metric/extraction_metric.h"
 %include "interop/logic/metric/q_metric.h"
 %include "interop/model/run_metrics.h"
 %include "interop/logic/utils/metric_type_ext.h"
+%include "interop/logic/utils/metrics_to_load.h"
 
 
 

--- a/src/interop/CMakeLists.txt
+++ b/src/interop/CMakeLists.txt
@@ -25,8 +25,7 @@ set(SRCS
         logic/table/create_imaging_table_columns.cpp
         logic/table/create_imaging_table.cpp
         util/time.cpp
-        util/filesystem.cpp
-        )
+        util/filesystem.cpp logic/utils/metrics_to_load.cpp)
 
 set(HEADERS
         ../../interop/model/summary/cycle_state_summary.h
@@ -137,7 +136,7 @@ set(HEADERS
         ../../interop/logic/table/table_util.h
         ../../interop/io/table/imaging_table_csv.h
         ../../interop/logic/table/check_imaging_table_column.h
-        ../../interop/logic/table/table_populator.h)
+        ../../interop/logic/table/table_populator.h ../../interop/logic/utils/metrics_to_load.h)
 
 set(INTEROP_HEADERS ${HEADERS} PARENT_SCOPE)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" OR CMAKE_COMPILER_IS_GNUCC)

--- a/src/interop/logic/plot/plot_by_cycle.cpp
+++ b/src/interop/logic/plot/plot_by_cycle.cpp
@@ -382,28 +382,4 @@ namespace illumina { namespace interop { namespace logic { namespace plot
             names.push_back(utils::to_description(types[i]));
         }
     }
-
-    /** List the required on demand metrics
-     *
-     * @param type specific metric value to plot by cycle
-     * @param valid_to_load list of metrics to load on demand
-     */
-    void list_plot_by_cycle_metrics(const constants::metric_type type, std::vector<unsigned char>& valid_to_load)
-    {
-        if(valid_to_load.size() != constants::MetricCount) valid_to_load.assign(constants::MetricCount, 0);
-        valid_to_load[utils::to_group(type)]=static_cast<unsigned char>(1);
-    }
-    /** List the required on demand metrics
-     *
-     * @param metric_name name of metric value to plot by cycle
-     * @param valid_to_load list of metrics to load on demand
-     */
-    void list_plot_by_cycle_metrics(const std::string& metric_name, std::vector<unsigned char>& valid_to_load)
-    throw(model::invalid_metric_type)
-    {
-        const constants::metric_type type = constants::parse<constants::metric_type>(metric_name);
-        if(type == constants::UnknownMetricType)
-            INTEROP_THROW(model::invalid_metric_type, "Unsupported metric type: " << metric_name);
-        list_plot_by_cycle_metrics(type, valid_to_load);
-    }
 }}}}

--- a/src/interop/logic/plot/plot_by_cycle.cpp
+++ b/src/interop/logic/plot/plot_by_cycle.cpp
@@ -382,4 +382,28 @@ namespace illumina { namespace interop { namespace logic { namespace plot
             names.push_back(utils::to_description(types[i]));
         }
     }
+
+    /** List the required on demand metrics
+     *
+     * @param type specific metric value to plot by cycle
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_plot_by_cycle_metrics(const constants::metric_type type, std::vector<unsigned char>& valid_to_load)
+    {
+        if(valid_to_load.size() != constants::MetricCount) valid_to_load.assign(constants::MetricCount, 0);
+        valid_to_load[utils::to_group(type)]=static_cast<unsigned char>(1);
+    }
+    /** List the required on demand metrics
+     *
+     * @param metric_name name of metric value to plot by cycle
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_plot_by_cycle_metrics(const std::string& metric_name, std::vector<unsigned char>& valid_to_load)
+    throw(model::invalid_metric_type)
+    {
+        const constants::metric_type type = constants::parse<constants::metric_type>(metric_name);
+        if(type == constants::UnknownMetricType)
+            INTEROP_THROW(model::invalid_metric_type, "Unsupported metric type: " << metric_name);
+        list_plot_by_cycle_metrics(type, valid_to_load);
+    }
 }}}}

--- a/src/interop/logic/plot/plot_by_lane.cpp
+++ b/src/interop/logic/plot/plot_by_lane.cpp
@@ -199,4 +199,5 @@ namespace illumina { namespace interop { namespace logic { namespace plot
         }
     }
 
+
 }}}}

--- a/src/interop/logic/summary/index_summary.cpp
+++ b/src/interop/logic/summary/index_summary.cpp
@@ -160,5 +160,4 @@ namespace illumina { namespace interop { namespace logic { namespace summary {
                                 summary);
     }
 
-
 }}}}

--- a/src/interop/logic/summary/run_summary.cpp
+++ b/src/interop/logic/summary/run_summary.cpp
@@ -13,6 +13,7 @@
 #include "interop/logic/summary/quality_summary.h"
 #include "interop/logic/utils/channel.h"
 #include "interop/logic/metric/q_metric.h"
+#include "interop/util/length_of.h"
 
 
 namespace illumina { namespace interop { namespace logic { namespace summary
@@ -95,7 +96,7 @@ namespace illumina { namespace interop { namespace logic { namespace summary
                                      summary);
 
         if(0 == metrics.get_set<q_collapsed_metric>().size())
-            logic::metric::create_collapse_q_metrics(metrics.get_set<model::metrics::q_metric>(),
+            logic::metric::create_collapse_q_metrics(metrics.get_set<q_metric>(),
                                                      metrics.get_set<q_collapsed_metric>());
         summarize_collapsed_quality_metrics(metrics.get_set<q_collapsed_metric>().begin(),
                                             metrics.get_set<q_collapsed_metric>().end(),

--- a/src/interop/logic/table/create_imaging_table.cpp
+++ b/src/interop/logic/table/create_imaging_table.cpp
@@ -324,7 +324,7 @@ namespace illumina { namespace interop { namespace logic { namespace table
      *
      * @param valid_to_load list of metrics to load on demand
      */
-    void list_imaging_table_metrics(std::vector<unsigned char>& valid_to_load)
+    void list_imaging_table_metrics_to_load(std::vector<unsigned char>& valid_to_load)
     {
         if(valid_to_load.size() != constants::MetricCount) valid_to_load.assign(constants::MetricCount, 0);
         std::vector<model::table::column_id> columns;

--- a/src/interop/logic/utils/metrics_to_load.cpp
+++ b/src/interop/logic/utils/metrics_to_load.cpp
@@ -1,0 +1,129 @@
+/** Collection of utilities for metric listing
+ *
+ *  @file
+ *  @date  4/28/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#include "interop/util/exception.h"
+#include "interop/logic/utils/metrics_to_load.h"
+#include "interop/logic/utils/metric_type_ext.h"
+#include "interop/model/run_metrics.h"
+
+namespace illumina { namespace interop { namespace logic { namespace utils
+{
+
+    /** List the required on demand metrics
+     *
+     * @param group specific metric group to load
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_metrics_to_load(const constants::metric_group group, std::vector<unsigned char>& valid_to_load)
+    {
+        if(valid_to_load.size() != constants::MetricCount) valid_to_load.assign(constants::MetricCount, 0);
+        if(group < constants::MetricCount)
+        {
+            valid_to_load[group] = static_cast<unsigned char>(1);
+        }
+    }
+
+    /** List the required on demand metrics
+     *
+     * @param type specific metric type to load
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_metrics_to_load(const constants::metric_type type, std::vector<unsigned char>& valid_to_load)
+    {
+        list_metrics_to_load(utils::to_group(type), valid_to_load);
+    }
+    /** List the required on demand metrics
+     *
+     * @param groups collection of specific metric groups to load
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_metrics_to_load(const std::vector<constants::metric_group>& groups,
+                              std::vector<unsigned char>& valid_to_load)
+    {
+        for(std::vector<constants::metric_group>::const_iterator it = groups.begin();it != groups.end();++it)
+            list_metrics_to_load(*it, valid_to_load);
+    }
+    /** List the required on demand metrics
+     *
+     * @param types collection of specific metric types to load
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_metrics_to_load(const std::vector<constants::metric_type>& types,
+                              std::vector<unsigned char>& valid_to_load)
+    {
+        for(std::vector<constants::metric_type>::const_iterator it = types.begin();it != types.end();++it)
+            list_metrics_to_load(*it, valid_to_load);
+    }
+    /** List the required on demand metrics
+     *
+     * @param metric_name name of metric value to load
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_metrics_to_load(const std::string& metric_name, std::vector<unsigned char>& valid_to_load)
+    throw(model::invalid_metric_type)
+    {
+        const constants::metric_type type = constants::parse<constants::metric_type>(metric_name);
+        if(type == constants::UnknownMetricType)
+            INTEROP_THROW(model::invalid_metric_type, "Unsupported metric type: " << metric_name);
+        list_metrics_to_load(type, valid_to_load);
+    }
+
+    /** List all required metric groups
+     *
+     * @param groups destination group list
+     */
+    void list_index_summary_metric_groups(std::vector<constants::metric_group>& groups)
+    {
+        using namespace model::metrics;
+        groups.clear();
+        const constants::metric_group group_set[] = {
+                static_cast<constants::metric_group >(index_metric::TYPE),
+                static_cast<constants::metric_group >(tile_metric::TYPE)
+        };
+        groups.assign(group_set, group_set+util::length_of(group_set));
+    }
+
+    /** List all required metric groups
+     *
+     * @param groups destination group list
+     */
+    void list_summary_metric_groups(std::vector<constants::metric_group>& groups)
+    {
+        using namespace model::metrics;
+        groups.clear();
+        const constants::metric_group group_set[] = {
+                static_cast<constants::metric_group >(q_metric::TYPE),
+                static_cast<constants::metric_group >(tile_metric::TYPE),
+                static_cast<constants::metric_group >(error_metric::TYPE),
+                static_cast<constants::metric_group >(extraction_metric::TYPE),
+                static_cast<constants::metric_group >(corrected_intensity_metric::TYPE)
+        };
+        groups.assign(group_set, group_set+util::length_of(group_set));
+    }
+    /** List all required metric groups
+     *
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_summary_metrics_to_load(std::vector<unsigned char>& valid_to_load)
+    {
+        std::vector<constants::metric_group> groups;
+        list_summary_metric_groups(groups);
+        logic::utils::list_metrics_to_load(groups, valid_to_load); // Only load the InterOp files required
+    }
+
+    /** List all required metric groups
+     *
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_index_metrics_to_load(std::vector<unsigned char>& valid_to_load)
+    {
+        std::vector<constants::metric_group> groups;
+        list_index_summary_metric_groups(groups);
+        logic::utils::list_metrics_to_load(groups, valid_to_load); // Only load the InterOp files required
+    }
+
+}}}}

--- a/src/interop/model/metrics/q_metric.cpp
+++ b/src/interop/model/metrics/q_metric.cpp
@@ -413,7 +413,8 @@ namespace illumina { namespace interop { namespace io
                 template<class Stream, class Metric, class Header>
                 static std::streamsize map_stream(Stream& stream, Metric& metric, Header& header, const bool)
                 {
-                    const std::streamsize count = stream_map< count_t >(stream, metric.m_qscore_hist, header.bin_count());
+                    const size_t bin_count = (header.bin_count() == 0) ? static_cast<size_t>(q_metric::MAX_Q_BINS) : header.bin_count();
+                    const std::streamsize count = stream_map< count_t >(stream, metric.m_qscore_hist, bin_count);
                     resize_accumulated(stream, metric);
                     return count;
                 }
@@ -423,7 +424,8 @@ namespace illumina { namespace interop { namespace io
                  */
                 static record_size_t compute_size(const q_metric::header_type& header)
                 {
-                    return static_cast<record_size_t>(sizeof(metric_id_t)+sizeof(count_t)*header.bin_count());
+                    const size_t bin_count = header.bin_count() == 0 ? static_cast<size_t>(q_metric::MAX_Q_BINS) : header.bin_count();
+                    return static_cast<record_size_t>(sizeof(metric_id_t)+sizeof(count_t)*bin_count);
                 }
                 /** Map reading/writing a header to a stream
                  *

--- a/src/interop/model/run/info.cpp
+++ b/src/interop/model/run/info.cpp
@@ -226,7 +226,7 @@ namespace illumina { namespace interop { namespace model { namespace run
         if(surface > m_flowcell.surface_count())
             INTEROP_THROW(invalid_run_info_exception, "Surface number exceeds number of surfaces");
         const ::uint32_t section = logic::metric::section(tile, m_flowcell.naming_method());
-        if(section > m_flowcell.sections_per_lane())
+        if(section > m_flowcell.sections_per_lane() * m_flowcell.lanes_per_section())
             INTEROP_THROW(invalid_run_info_exception, "Section number exceeds number of sections");
     }
 

--- a/src/interop/model/run_metrics.cpp
+++ b/src/interop/model/run_metrics.cpp
@@ -117,13 +117,20 @@ namespace illumina { namespace interop { namespace model { namespace metrics
     struct read_func
     {
         typedef const unsigned char* bool_pointer;
-        read_func(const std::string &f, bool_pointer valid=0) : m_run_folder(f), m_valid(valid)
+        read_func(const std::string &f, bool_pointer load_metric_check=0) :
+                m_run_folder(f), m_load_metric_check(load_metric_check)
         {}
 
         template<class MetricSet>
         int operator()(MetricSet &metrics) const
         {
-            if(m_valid != 0 && m_valid[MetricSet::TYPE] == 0) return 0;
+            // If the m_load_metric_check is not set, read in the metric
+            // Otherwise, check if the metric should be read and that it is not empty
+            // This logic is for SAV OnDemand (TM) loading
+            if(m_load_metric_check != 0 && (m_load_metric_check[MetricSet::TYPE] == 0 || !metrics.empty()))
+            {
+                return 0;
+            }
             try
             {
                 io::read_interop(m_run_folder, metrics);
@@ -146,7 +153,7 @@ namespace illumina { namespace interop { namespace model { namespace metrics
         }
 
         std::string m_run_folder;
-        bool_pointer m_valid;
+        bool_pointer m_load_metric_check;
     };
 
     struct write_func

--- a/src/tests/interop/metrics/inc/q_metrics_test.h
+++ b/src/tests/interop/metrics/inc/q_metrics_test.h
@@ -341,6 +341,76 @@ namespace illumina{ namespace interop { namespace unittest {
         }
     };
 
+    /** This test writes three records of an InterOp files, then reads them back in and compares
+     * each value to ensure they did not change.
+     *
+     * @note Version 6
+     */
+    struct q_v6_unbinned : metric_test<model::metrics::q_metric, 6>
+    {
+        /** Build the expected metric set
+         *
+         * @return vector of metrics
+         */
+        static std::vector<metric_t> metrics()
+        {
+            std::vector<metric_t> expected_metrics;
+            typedef metric_t::uint_t uint_t;
+
+            std::vector<uint_t> hist_tmp(50, 0);
+
+            expected_metrics.push_back(metric_t(1, 1110, 1, hist_tmp));
+            expected_metrics.push_back(metric_t(1, 1110, 2, hist_tmp));
+            expected_metrics.push_back(metric_t(1, 1110, 3, hist_tmp));
+
+            return expected_metrics;
+        }
+        /** Get the expected metric set header
+         *
+         * @return expected metric set header
+         */
+        static header_t header()
+        {
+            typedef header_t::qscore_bin_vector_type qscore_bin_vector_type;
+            qscore_bin_vector_type headervec;
+            return header_t(headervec);
+        }
+        /** Get the expected binary data
+         *
+         * @return binary data string
+         */
+        static std::string binary_data()
+        {
+            const int tmp[] = {
+                    6,-50,0,1,0,86,4,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,86,4,2
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,1,0,86,4,3,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+                    ,0,0,0
+            };
+            return to_string(tmp);
+        }
+    };
+
     /** Interface between fixtures and Google Test */
     template<typename TestSetup>
     struct q_metrics_test : public ::testing::Test, public TestSetup { };

--- a/src/tests/interop/metrics/q_metrics_test.cpp
+++ b/src/tests/interop/metrics/q_metrics_test.cpp
@@ -26,7 +26,9 @@ typedef ::testing::Types<
         hardcoded_fixture<q_v5>,
         write_read_fixture<q_v5>,
         hardcoded_fixture<q_v6>,
-        write_read_fixture<q_v6>
+        write_read_fixture<q_v6>,
+        hardcoded_fixture<q_v6_unbinned>,
+        write_read_fixture<q_v6_unbinned>
 > Formats;
 TYPED_TEST_CASE(q_metrics_test, Formats);
 


### PR DESCRIPTION
This pull request contains an enhancement to the applications where only the InterOp files required are loaded by run_metrics (rather than all InterOps).

This also adds RunInfo.xml validation to ensure all the logic code works as expected.

There are two bug fixes:

1. Q-metrics V6 unbinned was not parsed properly, which resulted in an exception.
2. There was a dirty buffer in the latest refactor to the summary logic.