### PR TITLE
Improved InterOp loading speed and bug fix for std::vector usage

### DIFF
--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -1,5 +1,13 @@
 # Changes                                               {#changes}
 
+## Master
+
+Date       | Description
+---------- | -----------
+2016-09-07 | IPA-5101: Fix MSVC bug in vector type loading (Master)
+2016-09-02 | Added buffered reader to improve loading speed
+2016-09-01 | Bug fix for SWIG in on-demand loading
+
 ## v1.0.10
 
 Date       | Description

--- a/interop/constants/enums.h
+++ b/interop/constants/enums.h
@@ -10,6 +10,7 @@
 
 #include <climits>
 #include <limits>
+#include <string>
 #include "interop/util/cstdint.h"
 /** Enumeration of specific features that can belong to a metric
  *
@@ -279,6 +280,61 @@ namespace illumina { namespace interop { namespace constants
     enum metric_feature_type
     {
         INTEROP_ENUM_METRIC_FEATURE_TYPE
+    };
+    /** Encapsulates an enum and a string description
+     */
+    template<typename Enum>
+    class enum_description
+    {
+    public:
+        /** Type of the enum */
+        typedef Enum enum_t;
+
+    public:
+        /** Constructor */
+        enum_description() : m_value(static_cast<Enum>(constants::Unknown)){}
+        /** Constructor
+         *
+         * @param val enum value
+         * @param description enum description
+         */
+        enum_description(const enum_t val, const std::string& description) : m_value(val), m_description(description){}
+        /** Constructor
+         *
+         * @param pair enum value/description pair
+         */
+        enum_description(const std::pair<metric_type, std::string >& pair) :
+                m_value(pair.first), m_description(pair.second){}
+
+    public:
+        /** Get the value of the enum
+         *
+         * @return enum value
+         */
+        enum_t value()const
+        {
+            return m_value;
+        }
+        /** Get the description of the enum
+         *
+         * @return enum description
+         */
+        const std::string& description()const
+        {
+            return m_description;
+        }
+        /** Implicit conversion operator
+         *
+         * @return enum value
+         */
+        operator enum_t()const
+        {
+            return m_value;
+        }
+
+    private:
+        Enum m_value;
+        std::string m_description;
     };
 }}}
 

--- a/interop/io/format/abstract_metric_format.h
+++ b/interop/io/format/abstract_metric_format.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <istream>
-#include <ostream>
+#include <iosfwd>
 #include "interop/util/cstdint.h"
+#include "interop/model/metric_base/metric_set.h"
 
 namespace illumina { namespace interop { namespace io
 {
@@ -48,33 +48,15 @@ namespace illumina { namespace interop { namespace io
          * @return size of record in bytes
          */
         virtual size_t record_size(const header_t &header) const = 0;
-
-        /** Read the header describing metrics stored in a binary InterOp file
+        /** Read all the metrics into a metric set
          *
-         * @param in input stream containing binary InterOp file data
-         * @param header metric set header
-         * @return number of bytes in the record
+         * @param in input stream
+         * @param metric_set destination set of metrics
+         * @param file_size number of bytes in the file
          */
-        virtual std::streamsize read_header(std::istream &in, header_t &header) = 0;
-
-        /** Read a metric id from the given input stream
-         *
-         * @param in input stream containing binary InterOp file data
-         * @param metric metric
-         * @return number of bytes in the record
-         */
-        virtual std::streamsize read_metric_id(std::istream &in, metric_t &metric) = 0;
-
-        /** Read a single metric record from the given input stream
-         *
-         * @param in input stream containing binary InterOp file data
-         * @param metric metric
-         * @param header metric set header
-         * @param is_new true if the metric is new to the set
-         * @return number of bytes in the record
-         */
-        virtual std::streamsize read_metric(std::istream &in, metric_t &metric, const header_t &header,
-                                            const bool is_new) = 0;
+        virtual void read_metrics(std::istream& in,
+                                  model::metric_base::metric_set<Metric>& metric_set,
+                                  const size_t file_size)=0;
 
         /** Write a metric record to the given output stream
          *

--- a/interop/io/format/default_layout.h
+++ b/interop/io/format/default_layout.h
@@ -1,0 +1,59 @@
+/** Default layout for shared functions
+ *
+ *  @file
+ *  @date 8/15/15
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+
+#pragma once
+
+#include <ios>
+#include "interop/io/format/map_io.h"
+
+namespace illumina { namespace interop { namespace io
+{
+    /** Define default methods and typedefs for a record layout
+     */
+    template<int V, int MultiRecord=0>
+    struct default_layout
+    {
+        enum
+        {
+            /** Version of the format */
+            VERSION = V,
+            /** Flag indicating whether metric is split into multiple records in the InterOp file */
+            MULTI_RECORD=MultiRecord
+        };
+        /** Define a record size type */
+        typedef ::uint8_t record_size_t;
+        /** Define a version type */
+        typedef ::uint8_t version_t;
+
+        /** Map reading/writing a header to a stream
+         *
+         * Does nothing
+         *
+         * @return 0
+         */
+        template<class Stream, class Header>
+        static std::streamsize map_stream_for_header(Stream &, Header &)
+        {
+            return 0;
+        }
+
+        /** Map reading/writing the record size to the stream
+         *
+         * @param stream input/output stream
+         * @param record_size size of the record
+         * @return size of the record
+         */
+        template<class Stream, class RecordSize>
+        static RecordSize map_stream_record_size(Stream &stream, RecordSize record_size)
+        {
+            stream_map<RecordSize>(stream, record_size);
+            return record_size;
+        }
+    };
+}}}
+

--- a/interop/io/format/generic_layout.h
+++ b/interop/io/format/generic_layout.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <ios>
-#include "interop/io/format/map_io.h"
 
 namespace illumina { namespace interop { namespace io
 {
@@ -24,45 +23,6 @@ namespace illumina { namespace interop { namespace io
     template<class MetricType, int Version>
     struct generic_layout;
 
-    /** Define default methods and typedefs for a record layout
-     */
-    template<int V>
-    struct default_layout
-    {
-        /** Version of the format */
-        enum
-        {
-            VERSION = V
-        };
-        /** Define a record size type */
-        typedef ::uint8_t record_size_t;
-        /** Define a version type */
-        typedef ::uint8_t version_t;
 
-        /** Map reading/writing a header to a stream
-         *
-         * Does nothing
-         *
-         * @return 0
-         */
-        template<class Stream, class Header>
-        static std::streamsize map_stream_for_header(Stream &, Header &)
-        {
-            return 0;
-        }
-
-        /** Map reading/writing the record size to the stream
-         *
-         * @param stream input/output stream
-         * @param record_size size of the record
-         * @return size of the record
-         */
-        template<class Stream, class RecordSize>
-        static RecordSize map_stream_record_size(Stream &stream, RecordSize record_size)
-        {
-            stream_map<RecordSize>(stream, record_size);
-            return record_size;
-        }
-    };
 }}}
 

--- a/interop/io/format/map_io.h
+++ b/interop/io/format/map_io.h
@@ -27,7 +27,7 @@ namespace illumina { namespace interop { namespace io
     void copy_from(std::ostream &, const Source &, const Destination &)
     { }
 
-    /** Copy from the destination to the source
+    /** Copy from source to destination
      *
      * @param dst destination
      * @param src source
@@ -37,13 +37,13 @@ namespace illumina { namespace interop { namespace io
     {
         dst = src;
     }
-    /** Copy from the destination to the source
+    /** Copy from source to destination
      *
      * @param dst destination
      * @param src source
      */
     template<typename Source, typename Destination>
-    void copy_from(const char*, Destination &dst, const Source &src)
+    void copy_from(const char*, Destination &dst, const Source &src) // TODO: Simplify this entire file with templates
     {
         dst = src;
     }
@@ -177,6 +177,7 @@ namespace illumina { namespace interop { namespace io
     std::streamsize stream_map(std::istream &in, std::vector<ValueType>&vals, const size_t n)
     {
         vals.resize(n);
+        INTEROP_ASSERT(!vals.empty());
         return read_array_helper<ReadType,ValueType>::read_array_from_stream(in, &vals.front(), n);
     }
 
@@ -194,6 +195,7 @@ namespace illumina { namespace interop { namespace io
     std::streamsize stream_map(char*& in, std::vector<ValueType>&vals, const size_t n)
     {
         vals.resize(n);
+        INTEROP_ASSERT(!vals.empty());
         return read_array_helper<ReadType,ValueType>::read_array_from_stream(in, &vals.front(), n);
     }
 
@@ -211,6 +213,7 @@ namespace illumina { namespace interop { namespace io
     std::streamsize stream_map(std::istream &in, std::vector<ValueType> &vals, const size_t offset, const size_t n)
     {
         vals.resize(offset + n);
+        INTEROP_ASSERT(!vals.empty());
         return read_array_helper<ReadType,ValueType>::read_array_from_stream(in, &vals.front(), n, offset);
     }
 
@@ -228,6 +231,7 @@ namespace illumina { namespace interop { namespace io
     std::streamsize stream_map(char*& in, std::vector<ValueType> &vals, const size_t offset, const size_t n)
     {
         vals.resize(offset + n);
+        INTEROP_ASSERT(!vals.empty());
         return read_array_helper<ReadType,ValueType>::read_array_from_stream(in, &vals.front(), n, offset);
     }
 

--- a/interop/io/format/metric_format.h
+++ b/interop/io/format/metric_format.h
@@ -7,6 +7,10 @@
  *  @copyright GNU Public License.
  */
 #pragma once
+#ifdef _MSC_VER
+#pragma warning(disable:4702) // MSVC warns that there is unreachable code
+#endif
+
 
 #include "interop/util/exception.h"
 #include "interop/io/format/abstract_metric_format.h"
@@ -26,6 +30,10 @@ namespace illumina { namespace interop { namespace io
     template<class Metric, class Layout>
     struct metric_format : public abstract_metric_format<Metric>
     {
+    private:
+        typedef typename Metric::id_t id_t;
+        typedef std::map<id_t, size_t> offset_map_t;
+    public:
         /** Define the metric type */
         typedef Metric metric_t;
         /** Define the metric header type */
@@ -62,6 +70,42 @@ namespace illumina { namespace interop { namespace io
             Layout::map_stream(out, metric, header, false);
         }
 
+        /** Read all the metrics into a metric set
+         *
+         * @param in input stream
+         * @param metric_set destination set of metrics
+         * @param file_size size of the file
+         */
+        void read_metrics(std::istream& in, model::metric_base::metric_set<Metric>& metric_set, const size_t file_size)
+        {
+            const std::streamsize record_size = read_header(in, metric_set);
+            offset_map_t metric_offset_map;
+            metric_t metric(metric_set);
+            if(file_size > 0 && !Layout::MULTI_RECORD)
+            {
+                const size_t record_count = (file_size-header_size(metric_set))/record_size;
+                metric_set.resize(record_count);
+                std::vector<char> buffer(record_size);
+                while (in)
+                {
+                    char *in_ptr = &buffer.front();
+                    in.read(in_ptr, record_size);
+                    const std::streamsize count = in.gcount();
+                    // TODO: buffer up multiple records
+                    if(!test_stream(in, metric_offset_map, count, record_size)) break;
+                    read_record(in_ptr, metric_set, metric_offset_map, metric, record_size);
+                }
+            }
+            else
+            {
+                while (in)
+                {
+                    read_record(in, metric_set, metric_offset_map, metric, record_size);
+                }
+            }
+
+
+        }
         /** Read a metric set from the given input stream
          *
          * @param in input stream containing binary InterOp file data
@@ -70,14 +114,20 @@ namespace illumina { namespace interop { namespace io
          */
         std::streamsize read_header(std::istream &in, header_t &header)
         {
+            // TODO: optimize header reading with block read
             if (in.fail())
                 INTEROP_THROW(incomplete_file_exception, "Insufficient header data read from the file");
 
-            //if we're not actually reading the record size from the stream (the stream position is the same before and after),
+            //if we're not actually reading the record size from the stream
+            // (the stream position is the same before and after),
             // then don't compare the layout size against the record size
             const ::int64_t stream_position_pre_record_check = in.tellg();
             const std::streamsize record_size = Layout::map_stream_record_size(in,
                                                                                static_cast<record_size_t>(0));
+            if(record_size==0)
+            {
+                INTEROP_THROW(bad_format_exception, "Record size cannot be 0");
+            }
             const ::int64_t stream_position_post_record_check = in.tellg();
             Layout::map_stream_for_header(in, header);
 
@@ -91,20 +141,6 @@ namespace illumina { namespace interop { namespace io
                                            Metric::prefix() <<  " "  << Metric::suffix()  <<  " v"  <<
                                            Layout::VERSION);
             return layout_size;
-        }
-
-        /** Read a metric set from the given input stream
-         *
-         * @param in input stream containing binary InterOp file data
-         * @param metric metric
-         * @return number of bytes in the record
-         */
-        std::streamsize read_metric_id(std::istream &in, metric_t &metric)
-        {
-            metric_id_t id;
-            read_binary(in, id);
-            metric.set_base(id);
-            return in.gcount();
         }
 
         /** Calculate the size of a record
@@ -127,19 +163,6 @@ namespace illumina { namespace interop { namespace io
             return static_cast<size_t>(Layout::compute_header_size(header));
         }
 
-        /** Read a metric set from the given input stream
-         *
-         * @param in input stream containing binary InterOp file data
-         * @param metric metric
-         * @param header metric header
-         * @param is_new the metric does not already exist in the set
-         * @return number of bytes in the record
-         */
-        std::streamsize read_metric(std::istream &in, metric_t &metric, const header_t &header, const bool is_new)
-        {
-            return Layout::map_stream(in, metric, header, is_new);
-        }
-
         /** Get the version of this metric format
          *
          * @return version number
@@ -147,6 +170,69 @@ namespace illumina { namespace interop { namespace io
         ::int16_t version() const
         {
             return static_cast< ::int16_t >(Layout::VERSION);
+        }
+
+    private:
+        static bool test_stream(std::istream& in,
+                         const offset_map_t& metric_offset_map,
+                         const std::streamsize count,
+                         const std::streamsize record_size)
+        {
+            if (in.fail())
+            {
+                if (count == 0 && !metric_offset_map.empty()) return false;
+                INTEROP_THROW(incomplete_file_exception, "Insufficient data read from the file, got: " << count
+                                                         << " != expected: " << record_size);
+            }
+            return true;
+        }
+        static bool test_stream(const char*, const offset_map_t&, const std::streamsize, const std::streamsize)
+        {return true;}
+        template<typename InputStream>
+        static void read_record(InputStream& in,
+                         model::metric_base::metric_set<Metric>& metric_set,
+                         offset_map_t& metric_offset_map,
+                         metric_t& metric,
+                         const std::streamsize record_size)
+        {
+            metric_id_t id;
+
+            const std::streamsize read_byte_count = read_binary_with_count (in, id);
+            if(!test_stream(in, metric_offset_map, read_byte_count, record_size)) return;
+            std::streamsize count=read_byte_count;
+            if (id.is_valid(metric_t::CHECK_TILE_ID))
+            {
+                metric.set_base(id);// TODO replace with static call
+                if (metric_offset_map.find(metric.id()) == metric_offset_map.end())
+                {
+                    const size_t offset = metric_offset_map.size();
+                    if(offset>= metric_set.size()) metric_set.resize(offset+1);
+                    metric_set.at(offset).set_base(id);
+                    count += Layout::map_stream(in, metric_set.at(offset), metric_set, true);
+                    if(metric_set.at(offset).id()==0)//Avoid adding control lanes
+                    {
+                        metric_set.resize(offset);
+                    }
+                    else metric_offset_map[metric.id()] = offset;
+                }
+                else
+                {
+                    const size_t offset = metric_offset_map[metric.id()];
+                    INTEROP_ASSERTMSG(metric_set.at(offset).lane() != 0, offset);
+                    count += Layout::map_stream(in, metric_set.at(offset), metric_set, false);
+                    INTEROP_ASSERT(metric_set.at(offset).id()>0);
+                }
+            }
+            else
+            {
+                count += Layout::map_stream(in, metric, metric_set, true);
+                //TODO: replace with skip function
+            }
+            if(!test_stream(in, metric_offset_map, count, record_size)) return;
+            if (count != record_size)
+            {
+                INTEROP_THROW(bad_format_exception, "Record does not match expected size!");
+            }
         }
     };
 }}}

--- a/interop/io/format/metric_format_factory.h
+++ b/interop/io/format/metric_format_factory.h
@@ -12,9 +12,7 @@
 #include "interop/util/assert.h"
 #include "interop/io/format/abstract_metric_format.h"
 #include "interop/util/unique_ptr.h"
-#include "interop/util/lexical_cast.h"
 #include "interop/io/stream_exceptions.h"
-#include "interop/io/format/metric_format.h"
 
 /** Register a metric format with the factory
  *
@@ -24,6 +22,16 @@
 #define INTEROP_REGISTER_METRIC_GENERIC_LAYOUT(Metric, Version) \
     illumina::interop::io::metric_format_factory< Metric >  \
     illumina_interop_io_##Type##Metric##Version(new illumina::interop::io::metric_format<Metric, illumina::interop::io::generic_layout<Metric, Version> >);
+
+/** Register a metric format with the factory
+ *
+ * @param Metric metric class
+ * @param Proxy actual metric parser to use
+ * @param Version version number
+ */
+#define INTEROP_REGISTER_METRIC_ANOTHER_GENERIC_LAYOUT(Metric, Proxy, Version) \
+    illumina::interop::io::metric_format_factory< Proxy >  \
+    illumina_interop_io_##Type##Proxy##Version(new illumina::interop::io::metric_format<Proxy, illumina::interop::io::generic_layout<Metric, Version> >);
 
 /** Ensure that static libraries are properly linked
  *  This must be used in a function that will definitely be linked.
@@ -41,18 +49,6 @@
 
 namespace illumina { namespace interop { namespace io
 {
-    /** Metric type adapter
-     *
-     * This class allows a metric derived from another metric to use it's format
-     * For example, q_by_lane_metric uses the q_metric format
-     */
-    template<typename Metric>
-    struct metric_format_adapter
-    {
-        /** Define the template parameter as the target type */
-        typedef Metric metric_t;
-    };
-
     /** Factory for generating metric formats
      *
      * This class defines static methods to register a metric format. The registered metric formats can

--- a/interop/io/format/stream_membuf.h
+++ b/interop/io/format/stream_membuf.h
@@ -1,0 +1,40 @@
+/** Stream membuf class
+ *
+ *  @file
+ *  @date 9/3/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+
+#pragma once
+
+#include <istream>
+#include <cstddef>
+#include <vector>
+#include "interop/util/exception.h"
+#include "interop/io/stream_exceptions.h"
+#include "interop/util/lexical_cast.h"
+#include "interop/util/cstdint.h"
+
+namespace illumina { namespace interop { namespace io
+{
+    namespace detail
+    {
+        /** Memory buffer for a stream
+         *
+         * This class is used to turn a binary byte buffer into an input stream for reading.
+         */
+        struct membuf : std::streambuf
+        {
+            /** Constructor
+             *
+             * @param begin start iterator for a char buffer
+             * @param end end iterator for a char buffer
+             */
+            membuf(char *begin, char *end)
+            {
+                this->setg(begin, begin, end);
+            }
+        };
+    }
+}}}

--- a/interop/io/format/stream_util.h
+++ b/interop/io/format/stream_util.h
@@ -11,10 +11,12 @@
 #include <istream>
 #include <cstddef>
 #include <vector>
+#include <cstring>
 #include "interop/util/exception.h"
 #include "interop/io/stream_exceptions.h"
 #include "interop/util/lexical_cast.h"
 #include "interop/util/cstdint.h"
+#include "interop/io/format/stream_membuf.h"
 
 namespace illumina { namespace interop { namespace io
 {
@@ -40,6 +42,54 @@ namespace illumina { namespace interop { namespace io
     void read_binary(std::istream &in, T &buffer)
     {
         read_binary(in, &buffer, 1);
+    }
+    /** Read an array of data from an input stream
+     *
+     * @param in input stream
+     * @param buffer array of data
+     * @param n number of elements in the array
+     */
+    template<class T>
+    void read_binary(char*& in, T *buffer, const size_t n)
+    {
+        std::memcpy(reinterpret_cast<char *>(buffer), in, n * sizeof(T));
+        in+=n * sizeof(T);
+    }
+    /** Read an value of binary data from an input stream
+     *
+     * @param in input stream
+     * @param buffer destination
+     */
+    template<class T>
+    void read_binary(char*& in, T &buffer)
+    {
+        read_binary(in, &buffer, 1);
+    }
+
+    /** Read binary and return a count
+     *
+     * @param in input stream
+     * @param buffer destination
+     * @return number of bytes read
+     */
+    template<class T>
+    std::streamsize read_binary_with_count(std::istream &in, T &buffer)
+    {
+        read_binary(in, &buffer, 1);
+        return in.gcount();
+    }
+
+    /** Read binary and return
+     *
+     * @param in input stream
+     * @param buffer destination
+     * @return number of bytes read
+     */
+    template<class T>
+    std::streamsize read_binary_with_count(char*& in, T &buffer)
+    {
+        read_binary(in, &buffer, 1);
+        return static_cast<std::streamsize >(sizeof(T));
     }
 
     /** Read an value of binary data from an input stream

--- a/interop/io/format/stream_util.h
+++ b/interop/io/format/stream_util.h
@@ -114,6 +114,7 @@ namespace illumina { namespace interop { namespace io
     template<class T>
     void read_binary(std::istream &in, std::vector<T> &buffer, const size_t n)
     {
+        INTEROP_ASSERT(!buffer.empty());
         read_binary(in, &buffer.front(), n);
     }
 
@@ -125,6 +126,7 @@ namespace illumina { namespace interop { namespace io
     template<class T>
     void read_binary(std::istream &in, std::vector<T> &buffer)
     {
+        INTEROP_ASSERT(!buffer.empty());
         read_binary(in, &buffer.front(), buffer.size());
     }
 
@@ -177,6 +179,7 @@ namespace illumina { namespace interop { namespace io
     template<class T>
     void write_binary(std::ostream &out, const std::vector<T> &buffer, const size_t n)
     {
+        if(buffer.empty())return;
         write_binary(out, &buffer.front(), n);
     }
 

--- a/interop/io/layout/base_metric.h
+++ b/interop/io/layout/base_metric.h
@@ -63,9 +63,9 @@ namespace illumina { namespace interop { namespace io { namespace layout
          *
          * @return true if data is valid
          */
-        bool is_valid() const
+        bool is_valid(const bool check_tile) const
         {
-            return tile > 0 && lane > 0;
+            return (!check_tile || tile > 0) && lane > 0;
         }
 
         /** Lane number
@@ -111,9 +111,9 @@ namespace illumina { namespace interop { namespace io { namespace layout
          *
          * @return true if data is valid
          */
-        bool is_valid() const
+        bool is_valid(const bool check_tile) const
         {
-            return tile > 0 && lane > 0 && cycle > 0;
+            return base_metric::is_valid(check_tile) && cycle > 0;
         }
 
         /** Cycle number
@@ -156,9 +156,9 @@ namespace illumina { namespace interop { namespace io { namespace layout
          *
          * @return true if data is valid
          */
-        bool is_valid() const
+        bool is_valid(const bool check_tile) const
         {
-            return tile > 0 && lane > 0 && read > 0;
+            return base_metric::is_valid(check_tile) && read > 0;
         }
 
         /** Read number

--- a/interop/io/metric_file_stream.h
+++ b/interop/io/metric_file_stream.h
@@ -83,8 +83,7 @@ namespace illumina { namespace interop { namespace io
      */
     template<class MetricSet>
     void read_interop_from_string(const std::string& buffer, MetricSet& metrics)  throw
-    (interop::io::file_not_found_exception,
-    interop::io::bad_format_exception,
+    (interop::io::bad_format_exception,
     interop::io::incomplete_file_exception,
     model::index_out_of_bounds_exception)
     {
@@ -116,7 +115,7 @@ namespace illumina { namespace interop { namespace io
         const std::string file_name = interop_filename<MetricSet>(run_directory, use_out);
         std::ifstream fin(file_name.c_str(), std::ios::binary);
         if(!fin.good()) INTEROP_THROW(file_not_found_exception, "File not found: " << file_name);
-        read_metrics(fin, metrics, file_size(file_name));
+        read_metrics(fin, metrics, static_cast<size_t>(file_size(file_name)));
     }
     /** Check for the existence of the binary InterOp file into the given metric set
      *

--- a/interop/logic/plot/plot_by_cycle.h
+++ b/interop/logic/plot/plot_by_cycle.h
@@ -56,12 +56,7 @@ namespace illumina { namespace interop { namespace logic { namespace plot
      * @param types destination vector to fill with metric types
      * @param ignore_accumulated if true, ignore accumulated Q20 and Q30
      */
-    void list_by_cycle_metrics(std::vector<constants::metric_type>& types, const bool ignore_accumulated=false);
-    /** List metric type names available for by cycle plots
-     *
-     * @param names destination vector to fill with metric type names
-     * @param ignore_accumulated if true, ignore accumulated Q20 and Q30
-     */
-    void list_by_cycle_metrics(std::vector<std::string>& names, const bool ignore_accumulated=false);
+    void list_by_cycle_metrics(std::vector< logic::utils::metric_type_description_t > &types,
+                               const bool ignore_accumulated=false);
 
 }}}}

--- a/interop/logic/plot/plot_by_lane.h
+++ b/interop/logic/plot/plot_by_lane.h
@@ -55,13 +55,7 @@ namespace illumina { namespace interop { namespace logic { namespace plot
      * @param types destination vector to fill with metric types
      * @param ignore_pf if true, ignore density PF and cluster PF
      */
-    void list_by_lane_metrics(std::vector<constants::metric_type>& types, const bool ignore_pf=false);
-    /** List metric type names available for by lane plots
-     *
-     * @param names destination vector to fill with metric type names
-     * @param ignore_pf if true, ignore density PF and cluster PF
-     */
-    void list_by_lane_metrics(std::vector<std::string>& names, const bool ignore_pf=false);
+    void list_by_lane_metrics(std::vector< logic::utils::metric_type_description_t > &types, const bool ignore_pf=false);
 
 
 }}}}

--- a/interop/logic/plot/plot_flowcell_map.h
+++ b/interop/logic/plot/plot_flowcell_map.h
@@ -56,16 +56,15 @@ namespace illumina { namespace interop { namespace logic { namespace plot
                                   throw(model::invalid_filter_option,
                                   model::invalid_metric_type,
                                   model::index_out_of_bounds_exception);
-    /** List metric types available for flowcell
+
+    /** List metric type names available for subtile
      *
-     * @param types destination vector to fill with metric types
+     * @param types destination vector to fill with metric type names
+     * @param ignore_accumulated exclude accumulated q-metrics
      */
-    void list_flowcell_metrics(std::vector<constants::metric_type>& types);
-    /** List metric type names available for flowcell
-     *
-     * @param names destination vector to fill with metric type names
-     */
-    void list_flowcell_metrics(std::vector<std::string>& names);
+    void list_flowcell_metrics(std::vector< logic::utils::metric_type_description_t > &types,
+                               const bool ignore_accumulated=false);
+
     /** Calculate the required buffer size
      *
      * @param metrics run metrics

--- a/interop/logic/utils/metric_type_ext.h
+++ b/interop/logic/utils/metric_type_ext.h
@@ -43,6 +43,21 @@ namespace illumina { namespace interop {  namespace logic { namespace utils
 #       undef INTEROP_TUPLE4
         return util::constant_mapping_get(name_types, type, std::string("UnknownDescription"));
     }
+    /** Convert metric type to string description
+     *
+     * @param type metric type
+     * @return string description
+     */
+    inline void list_descriptions(std::vector< constants::enum_description< constants::metric_type> >& types )
+    {
+        using namespace constants;
+        // TODO: This can be reduced to a single macro define
+        typedef std::pair<metric_type, std::string > mapped_t;
+#       define INTEROP_TUPLE4(Metric, Description, Group, Feature) mapped_t(Metric,Description)
+        static const mapped_t name_types[] = {INTEROP_ENUM_METRIC_TYPES};
+#       undef INTEROP_TUPLE4
+        types.assign(name_types, name_types+util::length_of(name_types));
+    }
     /** Convert metric type to metric group
      *
      * @param type metric type

--- a/interop/logic/utils/metrics_to_load.h
+++ b/interop/logic/utils/metrics_to_load.h
@@ -12,6 +12,8 @@
 
 namespace illumina { namespace interop { namespace logic { namespace utils
 {
+    /** Define a metric type description */
+    typedef constants::enum_description< constants::metric_type> metric_type_description_t;
     /** List the required on demand metrics
      *
      * @param group specific metric group to load
@@ -59,17 +61,23 @@ namespace illumina { namespace interop { namespace logic { namespace utils
     void list_index_summary_metric_groups(std::vector<constants::metric_group>& groups);
 
 
-    /** List all required metric groups
+    /** List all required metric groups for the summary tab
      *
      * @param valid_to_load list of metrics to load on demand
      */
     void list_summary_metrics_to_load(std::vector<unsigned char>& valid_to_load);
 
-    /** List all required metric groups
+    /** List all required metric groups for the index tab
      *
      * @param valid_to_load list of metrics to load on demand
      */
     void list_index_metrics_to_load(std::vector<unsigned char>& valid_to_load);
+
+    /** List all required metric groups for the analysis tab
+     *
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_analysis_metrics_to_load(std::vector<unsigned char>& valid_to_load);
 
 
 }}}}

--- a/interop/model/metrics/corrected_intensity_metric.h
+++ b/interop/model/metrics/corrected_intensity_metric.h
@@ -84,6 +84,16 @@ namespace illumina { namespace interop { namespace model { namespace metrics
                 m_called_counts(constants::NUM_OF_BASES_AND_NC, 0),
                 m_signal_to_noise(std::numeric_limits<float>::quiet_NaN())
         { }
+        /** Constructor
+         */
+        corrected_intensity_metric(const header_type&) :
+                metric_base::base_cycle_metric(0, 0, 0),
+                m_average_cycle_intensity(0),
+                m_corrected_int_all(constants::NUM_OF_BASES, 0),
+                m_corrected_int_called(constants::NUM_OF_BASES, 0),
+                m_called_counts(constants::NUM_OF_BASES_AND_NC, 0),
+                m_signal_to_noise(std::numeric_limits<float>::quiet_NaN())
+        { }
 
         /** Constructor
          *

--- a/interop/model/metrics/error_metric.h
+++ b/interop/model/metrics/error_metric.h
@@ -54,6 +54,14 @@ namespace illumina { namespace interop { namespace model { namespace metrics
                 m_mismatch_cluster_count(MAX_MISMATCH, 0)
         {
         }
+        /** Constructor
+         */
+        error_metric(const header_type&) :
+                metric_base::base_cycle_metric(0, 0, 0),
+                m_error_rate(0),
+                m_mismatch_cluster_count(MAX_MISMATCH, 0)
+        {
+        }
 
         /** Constructor
          *

--- a/interop/model/metrics/extraction_metric.h
+++ b/interop/model/metrics/extraction_metric.h
@@ -67,6 +67,16 @@ namespace illumina { namespace interop { namespace model { namespace metrics
                 m_focus_scores(MAX_CHANNELS, 0)
         {
         }
+        /** Constructor
+         */
+        extraction_metric(const header_type&) :
+                metric_base::base_cycle_metric(0, 0, 0),
+                m_date_time_csharp(0),
+                m_date_time(0),
+                m_max_intensity_values(MAX_CHANNELS, 0),
+                m_focus_scores(MAX_CHANNELS, 0)
+        {
+        }
 
         /** Constructor
          *

--- a/interop/model/metrics/image_metric.h
+++ b/interop/model/metrics/image_metric.h
@@ -109,6 +109,16 @@ namespace illumina { namespace interop { namespace model { namespace metrics
                 m_max_contrast(MAX_CHANNELS, 0),
                 m_channel_count(0)
         { }
+        /** Constructor
+         *
+         * @param header metric set header
+         */
+        image_metric(const header_type& header) :
+                metric_base::base_cycle_metric(0, 0, 0),
+                m_min_contrast(header.channel_count(), 0),
+                m_max_contrast(header.channel_count(), 0),
+                m_channel_count(0)
+        { }
 
         /** Constructor
          *

--- a/interop/model/metrics/index_metric.h
+++ b/interop/model/metrics/index_metric.h
@@ -15,6 +15,7 @@
 
 #include <string>
 #include <map>
+#include <vector>
 #include "interop/util/exception.h"
 #include "interop/util/assert.h"
 #include "interop/model/metric_base/base_read_metric.h"
@@ -176,6 +177,12 @@ namespace illumina { namespace interop { namespace model { namespace metrics
         /** Constructor
          */
         index_metric() :
+                metric_base::base_read_metric(0, 0, 0)
+        {
+        }
+        /** Constructor
+         */
+        index_metric(const header_type&) :
                 metric_base::base_read_metric(0, 0, 0)
         {
         }

--- a/interop/model/metrics/q_by_lane_metric.h
+++ b/interop/model/metrics/q_by_lane_metric.h
@@ -35,6 +35,13 @@ namespace illumina { namespace interop { namespace model { namespace metrics
         q_by_lane_metric() {}
         /** Constructor
          *
+         * @param header header of q-metric set
+         */
+        q_by_lane_metric(const header_type& header) : q_metric(header)
+        {
+        }
+        /** Constructor
+         *
          * @param lane lane number
          * @param tile tile number
          * @param cycle cycle number
@@ -81,17 +88,3 @@ namespace illumina { namespace interop { namespace model { namespace metrics
 
 }}}}
 
-namespace illumina { namespace interop { namespace io
-{
-    /** Specialization of metric type adapter
-     *
-     * This class allows a metric derived from another metric to use it's format
-     * For example, q_by_lane_metric uses the q_metric format
-     */
-    template<>
-    struct metric_format_adapter<model::metrics::q_by_lane_metric>
-    {
-        /** Define the template parameter as the target type */
-        typedef model::metrics::q_metric metric_t;
-    };
-}}}

--- a/interop/model/metrics/q_collapsed_metric.h
+++ b/interop/model/metrics/q_collapsed_metric.h
@@ -75,6 +75,17 @@ namespace illumina { namespace interop { namespace model { namespace metrics {
                 m_cumulative_q30(0),
                 m_cumulative_total(0) {}
         /** Constructor
+         */
+        q_collapsed_metric(const header_type&) :
+                metric_base::base_cycle_metric(0,0,0),
+                m_q20(0),
+                m_q30(0),
+                m_total(0),
+                m_median_qscore(0),
+                m_cumulative_q20(0),
+                m_cumulative_q30(0),
+                m_cumulative_total(0) {}
+        /** Constructor
          *
          * @param lane lane number
          * @param tile tile number

--- a/interop/model/metrics/q_metric.h
+++ b/interop/model/metrics/q_metric.h
@@ -259,6 +259,14 @@ namespace illumina { namespace interop { namespace model { namespace metrics
         q_metric() :
                 metric_base::base_cycle_metric(0, 0, 0)
         { }
+        /** Constructor
+         *
+         * @param header q-metric set header
+         */
+        q_metric(const header_type& header) :
+                metric_base::base_cycle_metric(0, 0, 0),
+                m_qscore_hist(header.bin_count()==0?static_cast<size_t>(MAX_Q_BINS):header.bin_count())
+        { }
 
         /** Constructor
          *
@@ -272,8 +280,7 @@ namespace illumina { namespace interop { namespace model { namespace metrics
                  const uint_t cycle,
                  const uint32_vector &qscore_hist) :
                 metric_base::base_cycle_metric(lane, tile, cycle),
-                m_qscore_hist(qscore_hist),
-                m_qscore_hist_cumulative(qscore_hist.size(), 0)
+                m_qscore_hist(qscore_hist)
         {
         }
 
@@ -291,8 +298,7 @@ namespace illumina { namespace interop { namespace model { namespace metrics
                  const uint_pointer_t qscore_hist,
                  const uint_t count) :
                 metric_base::base_cycle_metric(lane, tile, cycle),
-                m_qscore_hist(qscore_hist, qscore_hist + count),
-                m_qscore_hist_cumulative(count, 0)
+                m_qscore_hist(qscore_hist, qscore_hist + count)
         {
         }
 

--- a/interop/model/metrics/tile_metric.h
+++ b/interop/model/metrics/tile_metric.h
@@ -146,6 +146,14 @@ namespace illumina { namespace interop { namespace model { namespace metrics
                         m_cluster_count(0),
                         m_cluster_count_pf(0)
         { }
+        /** Constructor
+         */
+        tile_metric(const header_type&) : metric_base::base_metric(0, 0),
+                m_cluster_density(0),
+                m_cluster_density_pf(0),
+                m_cluster_count(0),
+                m_cluster_count_pf(0)
+        { }
 
         /** Constructor
          *

--- a/interop/model/model_exceptions.h
+++ b/interop/model/model_exceptions.h
@@ -6,7 +6,6 @@
  *  @copyright GNU Public License.
  */
 #pragma once
-
 #include <stdexcept>
 
 #ifdef _MSC_VER

--- a/interop/model/plot/filter_options.h
+++ b/interop/model/plot/filter_options.h
@@ -6,6 +6,10 @@
  *  @copyright GNU Public License.
  */
 #pragma once
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4290)// MSVC warns that it ignores the exception specification.
+#endif
 
 #include "interop/model/metric_base/base_metric.h"
 #include "interop/util/lexical_cast.h"
@@ -80,7 +84,9 @@ namespace illumina { namespace interop { namespace model { namespace plot
     public:
         /** Test if the filter options are valid, if not throw an exception
          */
-        void validate(const constants::metric_type type, const run::info& run_info, const bool check_ignored=false)const throw(model::invalid_filter_option)
+        void validate(const constants::metric_type type,
+                      const run::info& run_info,
+                      const bool check_ignored=false)const throw(model::invalid_filter_option)
         {
             if(m_naming_method == constants::UnknownTileNamingMethod)
                 INTEROP_THROW(model::invalid_filter_option, "Invalid tile naming method: Unknown");
@@ -589,3 +595,6 @@ namespace illumina { namespace interop { namespace model { namespace plot
 
 
 }}}}
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/interop/model/run_metrics.h
+++ b/interop/model/run_metrics.h
@@ -481,22 +481,6 @@ namespace illumina { namespace interop { namespace model { namespace metrics
          *
          * @param run_folder run folder path
          * @param valid_to_load list of metrics to load
-         * @param n number of elements in valid_to_load
-         */
-        void read_metrics(const std::string &run_folder, const unsigned char* valid_to_load, const size_t n) throw(
-        io::file_not_found_exception,
-        io::bad_format_exception,
-        io::incomplete_file_exception,
-        invalid_parameter);
-        /** Read binary metrics from the run folder
-         *
-         * This function ignores:
-         *  - Missing InterOp files
-         *  - Incomplete InterOp files
-         *  - Missing RunParameters.xml for non-legacy run folders
-         *
-         * @param run_folder run folder path
-         * @param valid_to_load list of metrics to load
          */
         void read_metrics(const std::string &run_folder, const std::vector<unsigned char>& valid_to_load) throw(
         io::file_not_found_exception,

--- a/interop/util/filesystem.h
+++ b/interop/util/filesystem.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <string>
+#include "interop/util/cstdint.h"
 
 namespace illumina { namespace interop { namespace io
 {
@@ -48,5 +49,13 @@ namespace illumina { namespace interop { namespace io
      * @return true if directory was created
      */
     bool mkdir(const std::string& path, const int mode=0733);
+    /** Get the size of a file
+     *
+     * This should be more efficient than opening a file and seeking the end.
+     *
+     * @param path path to the target file
+     * @return size of the file or -1 if the operation failed
+     */
+    ::int64_t file_size(const std::string& path);
 }}}
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,4 @@
 
-
 add_subdirectory("interop")
 
 if(ENABLE_SWIG)

--- a/src/ext/swig/metrics.i
+++ b/src/ext/swig/metrics.i
@@ -4,6 +4,7 @@
 %include <std_vector.i>
 %include <stdint.i>
 %include <std_map.i>
+%include <std_pair.i>
 %import "src/ext/swig/exceptions/exceptions_impl.i"
 %include "src/ext/swig/extends/extends_impl.i"
 %include "src/ext/swig/arrays/arrays_impl.i"
@@ -127,6 +128,12 @@ WRAP_METRICS(IMPORT_METRIC_WRAPPER)
 %template(cycle_metric_map) std::map< uint64_t, illumina::interop::model::metric_base::base_cycle_metric >;
 %template(read_metric_vector) std::vector< illumina::interop::model::metrics::read_metric >;
 %template(q_score_bin_vector) std::vector< illumina::interop::model::metrics::q_score_bin >;
+
+%template(metric_type_name_pair) std::pair< illumina::interop::constants::metric_type, std::string>;
+%template(metric_type_description) illumina::interop::constants::enum_description< illumina::interop::constants::metric_type>;
+%template(metric_type_description_vector) std::vector< illumina::interop::constants::enum_description< illumina::interop::constants::metric_type> >;
+
+// std::vector of enums causes a crash in Visual Studio C#
 %template(metric_type_vector) std::vector< illumina::interop::constants::metric_type>;
 %template(metric_group_vector) std::vector< illumina::interop::constants::metric_group>;
 

--- a/src/interop/CMakeLists.txt
+++ b/src/interop/CMakeLists.txt
@@ -136,7 +136,11 @@ set(HEADERS
         ../../interop/logic/table/table_util.h
         ../../interop/io/table/imaging_table_csv.h
         ../../interop/logic/table/check_imaging_table_column.h
-        ../../interop/logic/table/table_populator.h ../../interop/logic/utils/metrics_to_load.h)
+        ../../interop/logic/table/table_populator.h
+        ../../interop/logic/utils/metrics_to_load.h
+        ../../interop/io/format/default_layout.h
+        ../../interop/io/format/stream_membuf.h
+        )
 
 set(INTEROP_HEADERS ${HEADERS} PARENT_SCOPE)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" OR CMAKE_COMPILER_IS_GNUCC)

--- a/src/interop/logic/plot/plot_by_cycle.cpp
+++ b/src/interop/logic/plot/plot_by_cycle.cpp
@@ -292,9 +292,9 @@ namespace illumina { namespace interop { namespace logic { namespace plot
      */
     template<class Point>
     void plot_by_cycle_t(model::metrics::run_metrics& metrics,
-                       const std::string& metric_name,
-                       const model::plot::filter_options& options,
-                       model::plot::plot_data<Point>& data)
+                         const std::string& metric_name,
+                         const model::plot::filter_options& options,
+                         model::plot::plot_data<Point>& data)
     {
         const constants::metric_type type = constants::parse<constants::metric_type>(metric_name);
         if(type == constants::UnknownMetricType)
@@ -349,37 +349,25 @@ namespace illumina { namespace interop { namespace logic { namespace plot
      * @param types destination vector to fill with metric types
      * @param ignore_accumulated if true, ignore accumulated Q20 and Q30
      */
-    void list_by_cycle_metrics(std::vector<constants::metric_type>& types, const bool ignore_accumulated)
+    void list_by_cycle_metrics(std::vector< logic::utils::metric_type_description_t >& types,
+                               const bool ignore_accumulated)
     {
-        types.clear();
-        std::vector<constants::metric_type> tmp;
-        constants::list_enums(tmp);
-        types.reserve(tmp.size());
-        for(size_t i=0;i<tmp.size();++i)
+        utils::list_descriptions(types);
+        std::vector< logic::utils::metric_type_description_t >::iterator dst = types.begin();
+        for(std::vector< logic::utils::metric_type_description_t >::iterator src = types.begin();src != types.end();++src)
         {
-            if(!utils::is_cycle_metric(tmp[i])) continue;
+            const constants::metric_type type = *src;
+            if(utils::to_feature(type) == constants::UnknownMetricFeature) continue;
             if(ignore_accumulated)
             {
-                if (tmp[i] == constants::AccumPercentQ20) continue;
-                if (tmp[i] == constants::AccumPercentQ30)continue;
+                if (type == constants::AccumPercentQ20) continue;
+                if (type == constants::AccumPercentQ30)continue;
             }
-            types.push_back(tmp[i]);
+            if(!utils::is_cycle_metric(type)) continue;
+            if(src != dst) std::swap(*src, *dst);
+            ++dst;
         }
-    }
-    /** List metric type names available for by cycle plots
-     *
-     * @param names destination vector to fill with metric type names
-     * @param ignore_accumulated if true, ignore accumulated Q20 and Q30
-     */
-    void list_by_cycle_metrics(std::vector<std::string>& names, const bool ignore_accumulated)
-    {
-        std::vector<constants::metric_type> types;
-        list_by_cycle_metrics(types, ignore_accumulated);
-        names.clear();
-        names.reserve(types.size());
-        for(size_t i=0;i<types.size();++i)
-        {
-            names.push_back(utils::to_description(types[i]));
-        }
+        types.resize(std::distance(types.begin(), dst));
+
     }
 }}}}

--- a/src/interop/logic/plot/plot_by_lane.cpp
+++ b/src/interop/logic/plot/plot_by_lane.cpp
@@ -163,40 +163,24 @@ namespace illumina { namespace interop { namespace logic { namespace plot
      * @param types destination vector to fill with metric types
      * @param ignore_pf if true, ignore density PF and cluster PF
      */
-    void list_by_lane_metrics(std::vector<constants::metric_type>& types, const bool ignore_pf)
+    void list_by_lane_metrics(std::vector< logic::utils::metric_type_description_t >& types, const bool ignore_pf)
     {
-        std::vector<constants::metric_type> tmp;
-        constants::list_enums(tmp);
-        types.clear();
-        types.reserve(tmp.size());
-        for(size_t i=0;i<tmp.size();++i)
+        utils::list_descriptions(types);
+        std::vector< logic::utils::metric_type_description_t >::iterator dst = types.begin();
+        for(std::vector< logic::utils::metric_type_description_t >::iterator src = types.begin();src != types.end();++src)
         {
-            if(utils::to_feature(tmp[i]) == constants::UnknownMetricFeature) continue;
+            const constants::metric_type type = *src;
+            if(utils::to_feature(type) == constants::UnknownMetricFeature) continue;
             if(ignore_pf)
             {
-                if(tmp[i] == constants::ClustersPF) continue;
-                if(tmp[i] == constants::ClusterCountPF) continue;
+                if(type == constants::ClustersPF) continue;
+                if(type == constants::ClusterCountPF) continue;
             }
-            if(utils::is_cycle_metric(tmp[i])) continue;
-            types.push_back(tmp[i]);
+            if(utils::is_cycle_metric(type)) continue;
+            if(src != dst) std::swap(*src, *dst);
+            ++dst;
         }
-    }
-    /** List metric type names available for by lane plots
-     *
-     * @param names destination vector to fill with metric type names
-     * @param ignore_pf if true, ignore density PF and cluster PF
-     */
-    void list_by_lane_metrics(std::vector<std::string>& names, const bool ignore_pf)
-    {
-        std::vector<constants::metric_type> types;
-        list_by_lane_metrics(types, ignore_pf);
-
-        names.clear();
-        names.reserve(types.size());
-        for(size_t i=0;i<types.size();++i)
-        {
-            names.push_back(utils::to_description(types[i]));
-        }
+        types.resize(std::distance(types.begin(), dst));
     }
 
 

--- a/src/interop/logic/plot/plot_flowcell_map.cpp
+++ b/src/interop/logic/plot/plot_flowcell_map.cpp
@@ -221,38 +221,30 @@ namespace illumina { namespace interop { namespace logic { namespace plot
             INTEROP_THROW(model::invalid_metric_type, "Unsupported metric type: " << metric_name);
         plot_flowcell_map(metrics, type, options, data, buffer, tile_buffer);
     }
+
     /** List metric type names available for flowcell
      *
      * @param types destination vector to fill with metric type names
+     * @param ignore_accumulated exclude accumulated q-metrics
      */
-    void list_flowcell_metrics(std::vector<constants::metric_type>& types)
+    void list_flowcell_metrics(std::vector< logic::utils::metric_type_description_t > &types,
+                               const bool ignore_accumulated)
     {
-        types.clear();
-        std::vector<constants::metric_type> tmp;
-        constants::list_enums(tmp);
-        types.reserve(tmp.size());
-        for(size_t i=0;i<tmp.size();++i)
+        utils::list_descriptions(types);
+        std::vector< logic::utils::metric_type_description_t >::iterator dst = types.begin();
+        for(std::vector< logic::utils::metric_type_description_t >::iterator src = types.begin();src != types.end();++src)
         {
-            if(utils::to_feature(tmp[i]) == constants::UnknownMetricFeature) continue;
-            if(tmp[i] == constants::AccumPercentQ20) continue;
-            if(tmp[i] == constants::AccumPercentQ30)continue;
-            types.push_back(tmp[i]);
+            const constants::metric_type type = *src;
+            if(utils::to_feature(type) == constants::UnknownMetricFeature) continue;
+            if(ignore_accumulated)
+            {
+                if (type == constants::AccumPercentQ20) continue;
+                if (type == constants::AccumPercentQ30)continue;
+            }
+            if(src != dst) std::swap(*src, *dst);
+            ++dst;
         }
-    }
-    /** List metric type names available for flowcell
-     *
-     * @param names destination vector to fill with metric type names
-     */
-    void list_flowcell_metrics(std::vector<std::string>& names)
-    {
-        std::vector<constants::metric_type> types;
-        list_flowcell_metrics(types);
-        names.clear();
-        names.reserve(types.size());
-        for(size_t i=0;i<types.size();++i)
-        {
-            names.push_back(utils::to_description(types[i]));
-        }
+        types.resize(std::distance(types.begin(), dst));
     }
     /** Calculate the required buffer size
      *

--- a/src/interop/logic/table/create_imaging_table_columns.cpp
+++ b/src/interop/logic/table/create_imaging_table_columns.cpp
@@ -94,7 +94,8 @@ namespace illumina { namespace interop { namespace logic { namespace table
     void create_imaging_table_columns(const std::vector<std::string>& channels,
                                              const std::vector<bool>& filled,
                                              std::vector< model::table::imaging_column >& columns)
-    throw(model::invalid_column_type, model::index_out_of_bounds_exception)
+    throw(model::invalid_column_type,
+    model::index_out_of_bounds_exception)
     {
         columns.clear();
         columns.reserve(model::table::ImagingColumnCount+channels.size()+constants::NUM_OF_BASES);

--- a/src/interop/logic/utils/metrics_to_load.cpp
+++ b/src/interop/logic/utils/metrics_to_load.cpp
@@ -9,6 +9,7 @@
 #include "interop/logic/utils/metrics_to_load.h"
 #include "interop/logic/utils/metric_type_ext.h"
 #include "interop/model/run_metrics.h"
+#include "interop/logic/plot/plot_flowcell_map.h"
 
 namespace illumina { namespace interop { namespace logic { namespace utils
 {
@@ -125,5 +126,18 @@ namespace illumina { namespace interop { namespace logic { namespace utils
         list_index_summary_metric_groups(groups);
         logic::utils::list_metrics_to_load(groups, valid_to_load); // Only load the InterOp files required
     }
+    /** List all required metric groups for the analysis tab
+     *
+     * @param valid_to_load list of metrics to load on demand
+     */
+    void list_analysis_metrics_to_load(std::vector<unsigned char>& valid_to_load)
+    {
+        typedef std::vector< metric_type_description_t > description_vector_t;
+        description_vector_t types;
+        logic::plot::list_flowcell_metrics(types);
+        for(description_vector_t::const_iterator it = types.begin();it != types.end();++it)
+            list_metrics_to_load(*it, valid_to_load);
+    }
+
 
 }}}}

--- a/src/interop/model/metrics/corrected_intensity_metric.cpp
+++ b/src/interop/model/metrics/corrected_intensity_metric.cpp
@@ -10,6 +10,8 @@
 
 #include "interop/model/metrics/corrected_intensity_metric.h"
 #include "interop/io/format/metric_format_factory.h"
+#include "interop/io/format/default_layout.h"
+#include "interop/io/format/metric_format.h"
 
 
 using namespace illumina::interop::model::metrics;

--- a/src/interop/model/metrics/error_metric.cpp
+++ b/src/interop/model/metrics/error_metric.cpp
@@ -9,6 +9,8 @@
  */
 #include "interop/model/metrics/error_metric.h"
 #include "interop/io/format/metric_format_factory.h"
+#include "interop/io/format/default_layout.h"
+#include "interop/io/format/metric_format.h"
 
 using namespace illumina::interop::model::metrics;
 

--- a/src/interop/model/metrics/extraction_metric.cpp
+++ b/src/interop/model/metrics/extraction_metric.cpp
@@ -11,6 +11,8 @@
 #include "interop/util/math.h"
 #include "interop/model/metrics/extraction_metric.h"
 #include "interop/io/format/metric_format_factory.h"
+#include "interop/io/format/default_layout.h"
+#include "interop/io/format/metric_format.h"
 
 using namespace illumina::interop::model::metrics;
 
@@ -87,7 +89,7 @@ namespace illumina { namespace interop { namespace io
                 {
                     std::streamsize count = 0;
                     count += stream_map< focus_t >(stream, metric.m_focus_scores, extraction_metric::MAX_CHANNELS);
-                    if(stream.good())
+                    if(stream)
                         set_nan_to_zero(stream, metric.m_focus_scores);// TODO: Remove and rebaseline regression tests
                     count += stream_map< intensity_t >(stream, metric.m_max_intensity_values, extraction_metric::MAX_CHANNELS);
                     count += stream_map< datetime_t >(stream, metric.m_date_time_csharp.value);
@@ -119,6 +121,10 @@ namespace illumina { namespace interop { namespace io
                 static void convert_datetime(std::ostream&, const extraction_metric&)
                 {
                 }
+                static void convert_datetime(const char*, extraction_metric& metric)
+                {
+                    metric.m_date_time = metric.m_date_time_csharp.to_unix();
+                }
                 static void convert_datetime(std::istream& in, extraction_metric& metric)
                 {
                     if(in.fail()) return;
@@ -129,6 +135,11 @@ namespace illumina { namespace interop { namespace io
 
                 }
                 static void set_nan_to_zero(std::istream&, std::vector<float>& vals)
+                {
+                    for(size_t i=0;i<vals.size();++i)
+                        if(std::isnan(vals[i])) vals[i] = 0;
+                }
+                static void set_nan_to_zero(const char*, std::vector<float>& vals)
                 {
                     for(size_t i=0;i<vals.size();++i)
                         if(std::isnan(vals[i])) vals[i] = 0;

--- a/src/interop/model/metrics/extraction_metric.cpp
+++ b/src/interop/model/metrics/extraction_metric.cpp
@@ -91,6 +91,7 @@ namespace illumina { namespace interop { namespace io
                     count += stream_map< focus_t >(stream, metric.m_focus_scores, extraction_metric::MAX_CHANNELS);
                     if(stream)
                         set_nan_to_zero(stream, metric.m_focus_scores);// TODO: Remove and rebaseline regression tests
+                    else return count;
                     count += stream_map< intensity_t >(stream, metric.m_max_intensity_values, extraction_metric::MAX_CHANNELS);
                     count += stream_map< datetime_t >(stream, metric.m_date_time_csharp.value);
                     convert_datetime(stream, metric);

--- a/src/interop/model/metrics/image_metric.cpp
+++ b/src/interop/model/metrics/image_metric.cpp
@@ -11,6 +11,8 @@
 #include <algorithm>
 #include "interop/model/metrics/image_metric.h"
 #include "interop/io/format/metric_format_factory.h"
+#include "interop/io/format/default_layout.h"
+#include "interop/io/format/metric_format.h"
 
 using namespace illumina::interop::model::metrics;
 
@@ -29,7 +31,7 @@ namespace illumina { namespace interop { namespace io
              *      2. Version: 1
              */
             template<>
-            struct generic_layout<image_metric, 1> : public default_layout<1>
+            struct generic_layout<image_metric, 1> : public default_layout<1, 1 /*Multi record */>
             {
                 /** @page image_v1 Image Version 1
                  *
@@ -91,6 +93,11 @@ namespace illumina { namespace interop { namespace io
                     metric.m_min_contrast[rec.channel] = rec.min_contrast;
                     metric.m_max_contrast[rec.channel] = rec.max_contrast;
                     return count;
+                }
+                template<class Metric, class Header>
+                static std::streamsize map_stream(const char*, Metric&, Header&, const bool)
+                {
+                    INTEROP_THROW(std::runtime_error, "This function should not be called");
                 }
                 /** Write metric to the output stream
                  *

--- a/src/interop/model/metrics/index_metric.cpp
+++ b/src/interop/model/metrics/index_metric.cpp
@@ -10,6 +10,8 @@
 #include <string>
 #include "interop/model/metrics/index_metric.h"
 #include "interop/io/format/metric_format_factory.h"
+#include "interop/io/format/default_layout.h"
+#include "interop/io/format/metric_format.h"
 
 using namespace illumina::interop::model::metrics;
 
@@ -29,7 +31,7 @@ namespace illumina { namespace interop { namespace io
      *      2. Version: 1
      */
     template<>
-    struct generic_layout<index_metric, 1> : public default_layout<1>
+    struct generic_layout<index_metric, 1> : public default_layout<1, 1 /*Multi record */>
     {
         /** @page index_v1 Index Version 1
          *
@@ -107,6 +109,11 @@ namespace illumina { namespace interop { namespace io
             else beg->m_count += count;
 
             return BYTE_COUNT;
+        }
+        template<class Metric, class Header>
+        static std::streamsize map_stream(const char*, Metric&, Header&, const bool)
+        {
+            INTEROP_THROW(std::runtime_error, "This function should not be called");
         }
 
         /** Write metric to the output stream

--- a/src/interop/model/metrics/q_metric.cpp
+++ b/src/interop/model/metrics/q_metric.cpp
@@ -12,7 +12,10 @@
 #include <algorithm>
 #include "interop/util/assert.h"
 #include "interop/model/metrics/q_metric.h"
+#include "interop/model/metrics/q_by_lane_metric.h"
 #include "interop/io/format/metric_format_factory.h"
+#include "interop/io/format/default_layout.h"
+#include "interop/io/format/metric_format.h"
 
 using namespace illumina::interop::model::metrics;
 
@@ -98,6 +101,10 @@ namespace illumina { namespace interop { namespace io
                 }
 
             private:
+                static void resize_accumulated(const char*, q_metric& metric)
+                {
+                    metric.m_qscore_hist_cumulative.resize(metric.m_qscore_hist.size(), 0);
+                }
                 static void resize_accumulated(std::istream&, q_metric& metric)
                 {
                     metric.m_qscore_hist_cumulative.resize(metric.m_qscore_hist.size(), 0);
@@ -176,8 +183,8 @@ namespace illumina { namespace interop { namespace io
                  * @param header metric header
                  * @return number of bytes read or total number of bytes written
                  */
-                template<class Metric, class Header>
-                static std::streamsize map_stream(std::istream& stream, Metric& metric, Header& header, const bool)
+                template<class Stream, class Metric, class Header>
+                static std::streamsize map_stream(Stream& stream, Metric& metric, Header& header, const bool)
                 {
                     if(header.m_qscore_bins.size()>0)
                     {
@@ -328,6 +335,10 @@ namespace illumina { namespace interop { namespace io
                 static void copy_value_write(std::vector<q_score_bin>&, bin_t*) { }
 
             private:
+                static void resize_accumulated(const char*, q_metric& metric)
+                {
+                    metric.m_qscore_hist_cumulative.resize(metric.m_qscore_hist.size(), 0);
+                }
                 static void resize_accumulated(std::istream&, q_metric& metric)
                 {
                     metric.m_qscore_hist_cumulative.resize(metric.m_qscore_hist.size(), 0);
@@ -471,7 +482,8 @@ namespace illumina { namespace interop { namespace io
                  */
                 static record_size_t compute_header_size(const q_metric::header_type& header)
                 {
-                    if(header.bin_count()==0) return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(version_t) + sizeof(bool_t));
+                    if(header.bin_count()==0)
+                        return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(version_t) + sizeof(bool_t));
                     return static_cast<record_size_t>(sizeof(record_size_t) +
                            sizeof(version_t) + // version
                            sizeof(bool_t) + // has bins
@@ -525,6 +537,10 @@ namespace illumina { namespace interop { namespace io
                 static void copy_value_write(std::vector<q_score_bin>&, bin_t*) { }
 
             private:
+                static void resize_accumulated(const char*, q_metric& metric)
+                {
+                    metric.m_qscore_hist_cumulative.resize(metric.m_qscore_hist.size(), 0);
+                }
                 static void resize_accumulated(std::istream&, q_metric& metric)
                 {
                     metric.m_qscore_hist_cumulative.resize(metric.m_qscore_hist.size(), 0);
@@ -539,3 +555,8 @@ INTEROP_FORCE_LINK_DEF(q_metric)
 INTEROP_REGISTER_METRIC_GENERIC_LAYOUT(q_metric, 4 )
 INTEROP_REGISTER_METRIC_GENERIC_LAYOUT(q_metric, 5 )
 INTEROP_REGISTER_METRIC_GENERIC_LAYOUT(q_metric, 6 )
+
+INTEROP_FORCE_LINK_DEF(q_by_lane_metric)
+INTEROP_REGISTER_METRIC_ANOTHER_GENERIC_LAYOUT(q_metric, q_by_lane_metric, 4)
+INTEROP_REGISTER_METRIC_ANOTHER_GENERIC_LAYOUT(q_metric, q_by_lane_metric, 5)
+INTEROP_REGISTER_METRIC_ANOTHER_GENERIC_LAYOUT(q_metric, q_by_lane_metric, 6)

--- a/src/interop/model/metrics/tile_metric.cpp
+++ b/src/interop/model/metrics/tile_metric.cpp
@@ -11,6 +11,8 @@
 #include "interop/model/metrics/tile_metric.h"
 #include "interop/io/format/metric_format_factory.h"
 #include "interop/util/math.h"
+#include "interop/io/format/default_layout.h"
+#include "interop/io/format/metric_format.h"
 
 using namespace illumina::interop::model::metrics;
 
@@ -29,7 +31,7 @@ namespace illumina { namespace interop { namespace io
              *      2. Version: 2
              */
             template<>
-            struct generic_layout<tile_metric, 2> : public default_layout<2>
+            struct generic_layout<tile_metric, 2> : public default_layout<2, 1 /*Multi record */>
             {
                 /** @page tile_v2 Tile Version 2
                  *
@@ -139,6 +141,11 @@ namespace illumina { namespace interop { namespace io
                     };
 
                     return count;
+                }
+                template<class Metric, class Header>
+                static std::streamsize map_stream(const char*, Metric&, Header&, const bool)
+                {
+                    INTEROP_THROW(std::runtime_error, "This function should not be called");
                 }
                 /** Write metric to the output stream
                  *

--- a/src/interop/model/run_metrics.cpp
+++ b/src/interop/model/run_metrics.cpp
@@ -319,6 +319,7 @@ namespace illumina { namespace interop { namespace model { namespace metrics
         read_metrics(run_folder, valid_to_load);
         const size_t count = read_xml(run_folder);
         finalize_after_load(count);
+        check_for_data_sources(run_folder);
     }
 
     /** Read XML files: RunInfo.xml and possibly RunParameters.xml

--- a/src/interop/model/run_metrics.cpp
+++ b/src/interop/model/run_metrics.cpp
@@ -496,28 +496,7 @@ namespace illumina { namespace interop { namespace model { namespace metrics
     {
         m_metrics.apply(read_func(run_folder));
     }
-    /** Read binary metrics from the run folder
-     *
-     * This function ignores:
-     *  - Missing InterOp files
-     *  - Incomplete InterOp files
-     *  - Missing RunParameters.xml for non-legacy run folders
-     *
-     * @param run_folder run folder path
-     * @param valid_to_load list of metrics to load
-     * @param n number of elements in valid_to_load
-     */
-    void run_metrics::read_metrics(const std::string &run_folder, const unsigned char* valid_to_load, const size_t n)
-    throw( io::file_not_found_exception,
-    io::bad_format_exception,
-    io::incomplete_file_exception,
-    invalid_parameter)
-    {
-        if(n != constants::MetricCount)
-            INTEROP_THROW(invalid_parameter, "Boolean array valid_to_load does not match expected number of metrics: "
-            << n << " != " << constants::MetricCount);
-        m_metrics.apply(read_func(run_folder, valid_to_load));
-    }
+
     /** Read binary metrics from the run folder
      *
      * This function ignores:
@@ -534,7 +513,11 @@ namespace illumina { namespace interop { namespace model { namespace metrics
     io::incomplete_file_exception,
     invalid_parameter)
     {
-        read_metrics(run_folder, &valid_to_load.front(), valid_to_load.size());
+        if(valid_to_load.empty())return;
+        if(valid_to_load.size() != constants::MetricCount)
+            INTEROP_THROW(invalid_parameter, "Boolean array valid_to_load does not match expected number of metrics: "
+                    << valid_to_load.size() << " != " << constants::MetricCount);
+        m_metrics.apply(read_func(run_folder, &valid_to_load.front()));
     }
 
     /** Write binary metrics to the run folder
@@ -588,14 +571,6 @@ namespace illumina { namespace interop { namespace model { namespace metrics
     {
         m_metrics.apply(populate_tile_cycle_list(map));
     }
-    /** Validate whether the RunInfo.xml matches the InterOp files
-     *
-     * @throws invalid_run_info_exception
-     */
-    void run_metrics::validate() throw(invalid_run_info_exception)
-    {
-        m_metrics.apply(validate_run_info(m_run_info));
-    }
 
     /** Sort the metrics by lane, then tile, then cycle
      *
@@ -613,6 +588,14 @@ namespace illumina { namespace interop { namespace model { namespace metrics
     void run_metrics::check_for_data_sources(const std::string &run_folder)
     {
         m_metrics.apply(check_for_each_data_source(run_folder));
+    }
+    /** Validate whether the RunInfo.xml matches the InterOp files
+     *
+     * @throws invalid_run_info_exception
+     */
+    void run_metrics::validate() throw(invalid_run_info_exception)
+    {
+        m_metrics.apply(validate_run_info(m_run_info));
     }
 
 

--- a/src/interop/model/summary/run_summary.cpp
+++ b/src/interop/model/summary/run_summary.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include "interop/model/summary/run_summary.h"
 #include "interop/io/format/metric_format_factory.h"
+#include "interop/io/format/default_layout.h"
 
 using namespace illumina::interop::model::summary;
 using namespace illumina::interop;

--- a/src/interop/util/filesystem.cpp
+++ b/src/interop/util/filesystem.cpp
@@ -12,6 +12,8 @@
 
 #ifdef WIN32
 #include <direct.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 /** Platform dependent path separator */
 #define INTEROP_OS_SEP '\\'
 #else
@@ -128,6 +130,27 @@ namespace illumina { namespace interop { namespace io
 #       else
             return ::mkdir( path.c_str(), static_cast<mode_t>(mode)) == 0;
 #       endif
+    }
+
+    /** Get the size of a file
+     *
+     * This should be more efficient than opening a file and seeking the end.
+     *
+     * @param path path to the target file
+     * @return size of the file or -1 if the operation failed
+     */
+    ::int64_t file_size(const std::string& path)
+    {
+#       ifdef WIN32
+            struct __stat64 buf;
+            if (_stat64(path.c_str(), &buf) != 0)return -1; // error, could use errno to find out more
+            return buf.st_size;
+#       else
+            struct stat buf;
+            if (stat(path.c_str(), &buf) != 0)return -1; // error, could use errno to find out more
+            return buf.st_size;
+#       endif
+
     }
 }}}
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -31,9 +31,7 @@ endif()
 if(ENABLE_CSHARP)
     add_subdirectory("csharp")
     if(CSHARP_TEST_ENABLED)
-        add_custom_command(TARGET check POST_BUILD
-                COMMAND ${NUNIT_COMMAND_EXE} $<TARGET_FILE_DIR:${INTEROP_LIB}>/${CSHARP_UNIT_TEST_EXE})
-        add_dependencies(check csharp_unittest)
+        add_dependencies(check check_csharp)
 
         add_custom_command(TARGET performance POST_BUILD
                 COMMAND ${NUNIT_COMMAND_EXE} $<TARGET_FILE_DIR:${INTEROP_LIB}>/${CSHARP_PERF_TEST_EXE})

--- a/src/tests/csharp/CMakeLists.txt
+++ b/src/tests/csharp/CMakeLists.txt
@@ -51,8 +51,6 @@ add_custom_command(TARGET csharp_unittest POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy ${CSHARP_csharp_unittest_BINARY} $<TARGET_FILE_DIR:${INTEROP_LIB}>
         COMMAND ${CMAKE_COMMAND} -E copy ${NUNIT_LIBRARIES} $<TARGET_FILE_DIR:${INTEROP_LIB}>)
 
-set(CSHARP_UNIT_TEST_EXE "${CSHARP_csharp_unittest_BINARY_NAME}" PARENT_SCOPE)
-set(NUNIT_COMMAND_EXE "${NUNIT_COMMAND}" PARENT_SCOPE)
 
 if(NOT ENABLE_STATIC)
     add_custom_command(TARGET csharp_unittest POST_BUILD
@@ -76,8 +74,19 @@ add_custom_command(TARGET csharp_perftest POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy ${CSHARP_csharp_perftest_BINARY} $<TARGET_FILE_DIR:${INTEROP_LIB}>
         COMMAND ${CMAKE_COMMAND} -E copy ${NUNIT_LIBRARIES} $<TARGET_FILE_DIR:${INTEROP_LIB}>)
 
-set(CSHARP_PERF_TEST_EXE "${CSHARP_csharp_perftest_BINARY_NAME}" PARENT_SCOPE)
 if(NOT ENABLE_STATIC)
     add_custom_command(TARGET csharp_perftest POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE_DIR:${INTEROP_LIB}> ${CMAKE_CURRENT_BINARY_DIR})
 endif()
+
+add_custom_target(check_csharp
+        COMMENT "Running C# unit tests: ${NUNIT_COMMAND} $<TARGET_FILE_DIR:${INTEROP_LIB}>/${CSHARP_csharp_unittest_BINARY_NAME}}"
+        COMMAND ${NUNIT_COMMAND} $<TARGET_FILE_DIR:${INTEROP_LIB}>/${CSHARP_csharp_unittest_BINARY_NAME}
+        )
+
+add_dependencies(check_csharp csharp_unittest)
+set_target_properties(check_csharp PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
+
+
+set(NUNIT_COMMAND_EXE "${NUNIT_COMMAND}" PARENT_SCOPE)
+set(CSHARP_PERF_TEST_EXE "${CSHARP_csharp_perftest_BINARY_NAME}" PARENT_SCOPE)

--- a/src/tests/csharp/logic/PlotDataByCycleTest.cs
+++ b/src/tests/csharp/logic/PlotDataByCycleTest.cs
@@ -16,7 +16,7 @@ namespace Illumina.InterOp.Interop.UnitTest
 	{
 	    public void MetricTypeList()
      	{
-            var typeList = new metric_type_vector();
+            var typeList = new metric_type_description_vector();
             c_csharp_plot.list_by_cycle_metrics(typeList);
             Assert.AreEqual(typeList[0], metric_type.Intensity);
         }

--- a/src/tests/csharp/logic/PlotFlowcellMap.cs
+++ b/src/tests/csharp/logic/PlotFlowcellMap.cs
@@ -101,9 +101,7 @@ namespace Illumina.InterOp.Interop.UnitTest
 		public void TestListFlowMetrics()
 		{
 		    var interopsToLoad = new uchar_vector();
-		    var types = new metric_type_vector();
-		    c_csharp_plot.list_flowcell_metrics(types);
-		    c_csharp_metrics.list_metrics_to_load(types, interopsToLoad);
+		    c_csharp_metrics.list_analysis_metrics_to_load(interopsToLoad);
 		}
 	}
 }

--- a/src/tests/interop/logic/imaging_table_logic_test.cpp
+++ b/src/tests/interop/logic/imaging_table_logic_test.cpp
@@ -57,8 +57,7 @@ void simulate_read_error_metrics(model::metrics::run_metrics& metrics)
     metrics.legacy_channel_update(constants::HiSeq);
     metrics.set_naming_method(constants::FourDigit);
 
-    std::istringstream iss(unittest::error_v3::binary_data());
-    io::read_metrics(iss, metrics.get_set<model::metrics::error_metric>());
+    io::read_interop_from_string(unittest::error_v3::binary_data(), metrics.get_set<model::metrics::error_metric>());
 }
 /**
  * @class illumina::interop::model::table::imaging_table

--- a/src/tests/interop/logic/plot_logic_test.cpp
+++ b/src/tests/interop/logic/plot_logic_test.cpp
@@ -84,8 +84,8 @@ TEST(plot_logic, intensity_by_cycle)
     metrics.set_naming_method(constants::FourDigit);
     metrics.legacy_channel_update(constants::HiSeq);
 
-    std::istringstream iss(unittest::extraction_v2::binary_data());
-    io::read_metrics(iss, metrics.extraction_metric_set());
+    io::read_interop_from_string(unittest::extraction_v2::binary_data(),
+                                 metrics.get_set<model::metrics::extraction_metric>());
 
     model::plot::plot_data<model::plot::candle_stick_point> data;
     logic::plot::plot_by_cycle(metrics, constants::Intensity, options, data);
@@ -128,8 +128,7 @@ TEST(plot_logic, pf_clusters_by_lane)
     metrics.set_naming_method(constants::FourDigit);
     metrics.legacy_channel_update(constants::HiSeq);
 
-    std::istringstream iss(unittest::tile_v2::binary_data());
-    io::read_metrics(iss, metrics.tile_metric_set());
+    io::read_interop_from_string(unittest::tile_v2::binary_data(), metrics.get_set<model::metrics::tile_metric>());
 
     model::plot::plot_data<model::plot::candle_stick_point> data;
     logic::plot::plot_by_lane(metrics, constants::ClusterCountPF, options, data);
@@ -164,8 +163,7 @@ TEST(plot_logic, q_score_histogram)
     metrics.legacy_channel_update(constants::HiSeq);
     metrics.set_naming_method(constants::FourDigit);
 
-    std::istringstream iss(unittest::q_v6::binary_data());
-    io::read_metrics(iss, metrics.q_metric_set());
+    io::read_interop_from_string(unittest::q_v6::binary_data(), metrics.get_set<model::metrics::q_metric>());
     metrics.finalize_after_load();
 
     model::plot::plot_data<model::plot::bar_point> data;
@@ -200,8 +198,7 @@ TEST(plot_logic, q_score_heatmap)
     metrics.legacy_channel_update(constants::HiSeq);
     metrics.set_naming_method(constants::FourDigit);
 
-    std::istringstream iss(unittest::q_v6::binary_data());
-    io::read_metrics(iss, metrics.q_metric_set());
+    io::read_interop_from_string(unittest::q_v6::binary_data(), metrics.get_set<model::metrics::q_metric>());
     metrics.finalize_after_load();
 
     model::plot::heatmap_data data;
@@ -236,8 +233,7 @@ TEST(plot_logic, flowcell_map)
     model::plot::filter_options options(constants::FourDigit, ALL_IDS, 0, constants::A, ALL_IDS, 1, 1);
     metrics.legacy_channel_update(constants::HiSeq);
 
-    std::istringstream iss(unittest::extraction_v2::binary_data());
-    io::read_metrics(iss, metrics.extraction_metric_set());
+    io::read_interop_from_string(unittest::extraction_v2::binary_data(), metrics.get_set<model::metrics::extraction_metric>());
     ASSERT_GT(metrics.extraction_metric_set().size(), 0u);
 
     model::plot::flowcell_data data;
@@ -269,10 +265,8 @@ TEST(plot_logic, sample_qc)
     model::plot::filter_options options(constants::FourDigit, ALL_IDS, 0, constants::A, ALL_IDS, 1, 1);
     metrics.legacy_channel_update(constants::HiSeq);
 
-    std::istringstream iss(unittest::index_v1::binary_data());
-    io::read_metrics(iss, metrics.index_metric_set());
-    std::istringstream iss2(unittest::tile_v2::binary_data());
-    io::read_metrics(iss2, metrics.tile_metric_set());
+    io::read_interop_from_string(unittest::index_v1::binary_data(), metrics.get_set<model::metrics::index_metric>());
+    io::read_interop_from_string(unittest::tile_v2::binary_data(), metrics.get_set<model::metrics::tile_metric>());
     ASSERT_GT(metrics.index_metric_set().size(), 0u);
 
     model::plot::plot_data<model::plot::bar_point> data;

--- a/src/tests/interop/logic/plot_logic_test.cpp
+++ b/src/tests/interop/logic/plot_logic_test.cpp
@@ -22,7 +22,7 @@ using namespace illumina::interop;
 
 TEST(plot_logic, check_plot_by_cycle_list)
 {
-    std::vector<constants::metric_type> types;
+    std::vector<logic::utils::metric_type_description_t> types;
     logic::plot::list_by_cycle_metrics(types);
     for(size_t i=0;i<types.size();++i)
     {
@@ -34,7 +34,7 @@ TEST(plot_logic, check_plot_by_cycle_list)
 
 TEST(plot_logic, check_plot_by_lane_list)
 {
-    std::vector<constants::metric_type> types;
+    std::vector<logic::utils::metric_type_description_t> types;
     logic::plot::list_by_lane_metrics(types);
     for(size_t i=0;i<types.size();++i)
     {
@@ -45,7 +45,7 @@ TEST(plot_logic, check_plot_by_lane_list)
 
 TEST(plot_logic, check_plot_flowcell_list)
 {
-    std::vector<constants::metric_type> types;
+    std::vector< logic::utils::metric_type_description_t > types;
     logic::plot::list_flowcell_metrics(types);
     for(size_t i=0;i<types.size();++i)
     {
@@ -120,7 +120,7 @@ TEST(plot_logic, pf_clusters_by_lane)
             "",
             "",
             1,
-            model::run::flowcell_layout(2, 2, 2, 16),
+            model::run::flowcell_layout(8, 2, 2, 16),
             std::vector<std::string>(),
             model::run::image_dimensions(),
             reads

--- a/src/tests/interop/metrics/corrected_intensity_metrics_test.cpp
+++ b/src/tests/interop/metrics/corrected_intensity_metrics_test.cpp
@@ -96,9 +96,9 @@ TEST(corrected_intensity_metrics_test, test_percent_base_nan)
 TEST(run_metrics_corrected_intensity_test, test_is_group_empty)
 {
     run_metrics metrics;
-    std::istringstream fin(corrected_intensity_v2::binary_data());
     EXPECT_TRUE(metrics.is_group_empty(constants::CorrectedInt));
-    io::read_metrics(fin, metrics.get_set<corrected_intensity_metric>());
+    io::read_interop_from_string(corrected_intensity_v2::binary_data(),
+                                 metrics.get_set<corrected_intensity_metric>());
     EXPECT_FALSE(metrics.is_group_empty(constants::CorrectedInt));
 }
 

--- a/src/tests/interop/metrics/error_metrics_test.cpp
+++ b/src/tests/interop/metrics/error_metrics_test.cpp
@@ -62,9 +62,9 @@ TYPED_TEST(error_metrics_test, test_tile_metric_count_for_lane)
 TEST(run_metrics_error_test, test_is_group_empty)
 {
     run_metrics metrics;
-    std::istringstream fin(error_v3::binary_data());
     EXPECT_TRUE(metrics.is_group_empty(constants::Error));
-    io::read_metrics(fin, metrics.get_set<error_metric>());
+    io::read_interop_from_string(error_v3::binary_data(),
+                                 metrics.get_set<error_metric>());
     EXPECT_FALSE(metrics.is_group_empty(constants::Error));
 }
 

--- a/src/tests/interop/metrics/error_metrics_test2.cpp
+++ b/src/tests/interop/metrics/error_metrics_test2.cpp
@@ -89,8 +89,8 @@ TEST(run_metrics_error_metric_test, test_is_group_empty)
 {
     run_metrics metrics;
     EXPECT_TRUE(metrics.is_group_empty(constants::Error));
-    std::istringstream fin(error_metric_v3::binary_data());
-    io::read_metrics(fin, metrics.get_set<error_metric>());
+    io::read_interop_from_string(error_v3::binary_data(),
+                                 metrics.get_set<error_metric>());
     EXPECT_FALSE(metrics.is_group_empty(constants::Error));
 }
 

--- a/src/tests/interop/metrics/extraction_metrics_test.cpp
+++ b/src/tests/interop/metrics/extraction_metrics_test.cpp
@@ -63,8 +63,8 @@ TEST(run_metrics_extraction_test, test_is_group_empty)
 {
     run_metrics metrics;
     EXPECT_TRUE(metrics.is_group_empty(constants::Extraction));
-    std::istringstream fin(extraction_v2::binary_data());
-    io::read_metrics(fin, metrics.get_set<extraction_metric>());
+    io::read_interop_from_string(extraction_v2::binary_data(),
+                                 metrics.get_set<extraction_metric>());
     EXPECT_FALSE(metrics.is_group_empty(constants::Extraction));
 }
 

--- a/src/tests/interop/metrics/image_metrics_test.cpp
+++ b/src/tests/interop/metrics/image_metrics_test.cpp
@@ -60,8 +60,8 @@ TEST(run_metrics_image_test, test_is_group_empty)
 {
     run_metrics metrics;
     EXPECT_TRUE(metrics.is_group_empty(constants::Image));
-    std::istringstream fin(image_v1::binary_data());
-    io::read_metrics(fin, metrics.get_set<image_metric>());
+    io::read_interop_from_string(image_v1::binary_data(),
+                                 metrics.get_set<image_metric>());
     EXPECT_FALSE(metrics.is_group_empty(constants::Image));
 }
 #define FIXTURE image_metrics_test

--- a/src/tests/interop/metrics/inc/metric_generator.h
+++ b/src/tests/interop/metrics/inc/metric_generator.h
@@ -31,8 +31,8 @@ namespace illumina{ namespace interop { namespace unittest {
             Gen::create_expected(expected);
             try
             {
-                std::istringstream fin(Gen::binary_data());
-                illumina::interop::io::read_metrics(fin, actual);
+                io::read_interop_from_string(Gen::binary_data(),
+                                             actual);
             }
             catch (const std::exception &) { }
             return true;
@@ -64,8 +64,8 @@ namespace illumina{ namespace interop { namespace unittest {
             catch (const std::exception &) { }
             try
             {
-                std::istringstream fin(fout.str());
-                illumina::interop::io::read_metrics(fin, actual);
+                io::read_interop_from_string(fout.str(),
+                                             actual);
             }
             catch (const std::exception &) { }
             return true;

--- a/src/tests/interop/metrics/inc/metric_stream_tests.hpp
+++ b/src/tests/interop/metrics/inc/metric_stream_tests.hpp
@@ -42,9 +42,8 @@ WRAPPED_TEST(FIXTURE, test_hardcoded_bad_format_exception)
 {
     std::string tmp = std::string(expected);
     tmp[0] = 34;
-    std::istringstream fin(tmp);
     metric_set_t metrics;
-    EXPECT_THROW(illumina::interop::io::read_metrics(fin, metrics), bad_format_exception);
+    EXPECT_THROW(illumina::interop::io::read_interop_from_string(tmp, metrics), bad_format_exception);
 }
 
 /** Confirm incomplete_file_exception is thrown for a small partial record
@@ -54,10 +53,9 @@ WRAPPED_TEST(FIXTURE, test_hardcoded_incomplete_file_exception)
     ::uint32_t incomplete = 0;
     for(::uint32_t i=2;i<25;i++)
     {
-        std::istringstream fin(expected.substr(0, i));
         metric_set_t metrics;
         try{
-            illumina::interop::io::read_metrics(fin, metrics);
+            illumina::interop::io::read_interop_from_string(expected.substr(0, i), metrics);
         }
         catch(const incomplete_file_exception&){incomplete++;}
         catch(const std::exception& ex){ std::cerr << i << " " << ex.what() << std::endl;throw;}
@@ -68,9 +66,8 @@ WRAPPED_TEST(FIXTURE, test_hardcoded_incomplete_file_exception)
  */
 WRAPPED_TEST(FIXTURE, test_hardcoded_incomplete_file_exception_last_metric)
 {
-    std::istringstream fin(expected.substr(0,expected.length()-4));
     metric_set_t metrics;
-    EXPECT_THROW(illumina::interop::io::read_metrics(fin, metrics), incomplete_file_exception);
+    EXPECT_THROW(illumina::interop::io::read_interop_from_string(expected.substr(0,expected.length()-4), metrics), incomplete_file_exception);
 }
 /** Confirm bad_format_exception is thrown when record size is incorrect
  */
@@ -81,9 +78,8 @@ WRAPPED_TEST(FIXTURE, test_hardcoded_incorrect_record_size)
 #   endif
     std::string tmp = std::string(expected);
     tmp[1] = 0;
-    std::istringstream fin(tmp);
     metric_set_t metrics;
-    EXPECT_THROW(illumina::interop::io::read_metrics(fin, metrics), bad_format_exception);
+    EXPECT_THROW(illumina::interop::io::read_interop_from_string(tmp, metrics), bad_format_exception);
 }
 /** Confirm file_not_found_exception is thrown when a file is not found
  */
@@ -97,22 +93,19 @@ WRAPPED_TEST(FIXTURE, test_hardcoded_file_not_found)
 WRAPPED_TEST(FIXTURE, test_hardcoded_read)
 {
     std::string tmp = std::string(expected);
-    std::istringstream fin(tmp);
     metric_set_t metrics;
-    EXPECT_NO_THROW(illumina::interop::io::read_metrics(fin, metrics));
+    EXPECT_NO_THROW(illumina::interop::io::read_interop_from_string(tmp, metrics));
 }
 /** Confirm the clear function works
  */
 WRAPPED_TEST(FIXTURE, test_clear)
 {
     std::string tmp = std::string(expected);
-    std::istringstream fin(tmp);
     metric_set_t metrics;
-    EXPECT_NO_THROW(illumina::interop::io::read_metrics(fin, metrics));
+    EXPECT_NO_THROW(illumina::interop::io::read_interop_from_string(tmp, metrics));
     size_t cnt = metrics.size();
     metrics.clear();
-    std::istringstream fin2(tmp);
-    EXPECT_NO_THROW(illumina::interop::io::read_metrics(fin2, metrics));
+    EXPECT_NO_THROW(illumina::interop::io::read_interop_from_string(tmp, metrics));
     EXPECT_EQ(cnt, metrics.size());
 
 }

--- a/src/tests/interop/metrics/inc/metric_test.h
+++ b/src/tests/interop/metrics/inc/metric_test.h
@@ -137,8 +137,7 @@ namespace illumina{ namespace interop { namespace unittest {
         {
             try
             {
-                std::istringstream fin(data);
-                illumina::interop::io::read_metrics(fin, metrics);
+                illumina::interop::io::read_interop_from_string(data, metrics);
             }
             catch (const std::exception &) { }
         }

--- a/src/tests/interop/metrics/inc/stream_tests.hpp
+++ b/src/tests/interop/metrics/inc/stream_tests.hpp
@@ -53,9 +53,8 @@ WRAPPED_TEST(FIXTURE, test_hardcoded_bad_format_exception)
 {
     std::string tmp = std::string(TypeParam::expected_binary_data);
     tmp[0] = 34;
-    std::istringstream fin(tmp);
     typename TypeParam::metric_set_t metrics;
-    EXPECT_THROW(illumina::interop::io::read_metrics(fin, metrics), bad_format_exception);
+    EXPECT_THROW(illumina::interop::io::read_interop_from_string(tmp, metrics), bad_format_exception);
 }
 
 /** Confirm incomplete_file_exception is thrown for a small partial record
@@ -65,23 +64,23 @@ WRAPPED_TEST(FIXTURE, test_hardcoded_incomplete_file_exception)
     ::uint32_t incomplete = 0;
     for(::uint32_t i=2;i<25;i++)
     {
-        std::istringstream fin(TypeParam::expected_binary_data.substr(0, i));
         typename TypeParam::metric_set_t metrics;
         try{
-            illumina::interop::io::read_metrics(fin, metrics);
+            illumina::interop::io::read_interop_from_string(TypeParam::expected_binary_data.substr(0, i), metrics);
         }
         catch(const incomplete_file_exception&){incomplete++;}
         catch(const std::exception& ex){ std::cerr << i << " " << ex.what() << std::endl;throw;}
     }
-    EXPECT_TRUE(incomplete>10);
+    EXPECT_TRUE(incomplete>10) << "incomplete: " << incomplete;
 }
 /** Confirm incomplete_file_exception is thrown for a mostly complete file
  */
 WRAPPED_TEST(FIXTURE, test_hardcoded_incomplete_file_exception_last_metric)
 {
-    std::istringstream fin(TypeParam::expected_binary_data.substr(0,TypeParam::expected_binary_data.length()-4));
     typename TypeParam::metric_set_t metrics;
-    EXPECT_THROW(illumina::interop::io::read_metrics(fin, metrics), incomplete_file_exception);
+    EXPECT_THROW(illumina::interop::io::read_interop_from_string(
+            TypeParam::expected_binary_data.substr(0,TypeParam::expected_binary_data.length()-4), metrics),
+                 incomplete_file_exception);
 }
 /** Confirm bad_format_exception is thrown when record size is incorrect
  */
@@ -90,9 +89,8 @@ WRAPPED_TEST(FIXTURE, test_hardcoded_incorrect_record_size)
     if(TypeParam::disable_check_record_size) return;
     std::string tmp = std::string(TypeParam::expected_binary_data);
     tmp[1] = 0;
-    std::istringstream fin(tmp);
     typename TypeParam::metric_set_t metrics;
-    EXPECT_THROW(illumina::interop::io::read_metrics(fin, metrics), bad_format_exception);
+    EXPECT_THROW(illumina::interop::io::read_interop_from_string(tmp, metrics), bad_format_exception);
 }
 /** Confirm file_not_found_exception is thrown when a file is not found
  */
@@ -106,22 +104,19 @@ WRAPPED_TEST(FIXTURE, test_hardcoded_file_not_found)
 WRAPPED_TEST(FIXTURE, test_hardcoded_read)
 {
     std::string tmp = std::string(TypeParam::expected_binary_data);
-    std::istringstream fin(tmp);
     typename TypeParam::metric_set_t metrics;
-    EXPECT_NO_THROW(illumina::interop::io::read_metrics(fin, metrics));
+    EXPECT_NO_THROW(illumina::interop::io::read_interop_from_string(tmp, metrics));
 }
 /** Confirm the clear function works
  */
 WRAPPED_TEST(FIXTURE, test_clear)
 {
     std::string tmp = std::string(TypeParam::expected_binary_data);
-    std::istringstream fin(tmp);
     typename TypeParam::metric_set_t metrics;
-    EXPECT_NO_THROW(illumina::interop::io::read_metrics(fin, metrics));
+    EXPECT_NO_THROW(illumina::interop::io::read_interop_from_string(tmp, metrics));
     size_t cnt = metrics.size();
     metrics.clear();
-    std::istringstream fin2(tmp);
-    EXPECT_NO_THROW(illumina::interop::io::read_metrics(fin2, metrics));
+    EXPECT_NO_THROW(illumina::interop::io::read_interop_from_string(tmp, metrics));
     EXPECT_EQ(cnt, metrics.size());
 
 }

--- a/src/tests/interop/metrics/inc/summary_fixture.h
+++ b/src/tests/interop/metrics/inc/summary_fixture.h
@@ -39,8 +39,8 @@ namespace illumina{ namespace interop { namespace unittest {
             model::metrics::run_metrics metrics(run_info);
             try
             {
-                std::istringstream fin(Gen::binary_data());
-                illumina::interop::io::read_metrics(fin, metrics.get_set<typename Gen::metric_t>());
+                io::read_interop_from_string(Gen::binary_data(),
+                                             metrics.get_set<typename Gen::metric_t>());
             }
             catch (const std::exception &) { }
             metrics.finalize_after_load();

--- a/src/tests/interop/metrics/index_metrics_test.cpp
+++ b/src/tests/interop/metrics/index_metrics_test.cpp
@@ -54,8 +54,8 @@ TEST(run_metrics_index_test, test_is_group_empty)
 {
     run_metrics metrics;
     EXPECT_TRUE(metrics.is_group_empty(constants::Index));
-    std::istringstream fin(index_v1::binary_data());
-    io::read_metrics(fin, metrics.get_set<index_metric>());
+    io::read_interop_from_string(index_v1::binary_data(),
+                                 metrics.get_set<index_metric>());
     EXPECT_FALSE(metrics.is_group_empty(constants::Index));
 }
 #define FIXTURE index_metrics_test

--- a/src/tests/interop/metrics/q_by_lane_metric_test.cpp
+++ b/src/tests/interop/metrics/q_by_lane_metric_test.cpp
@@ -21,16 +21,16 @@ using namespace illumina::interop::unittest;
 TEST(q_by_lane_metrics_test, test_read_v4)
 {
     metric_set<q_by_lane_metric> metrics;
-    std::istringstream fin(q_v4::binary_data());
-    illumina::interop::io::read_metrics(fin, metrics);
+    io::read_interop_from_string(q_v4::binary_data(),
+                                 metrics);
 }
 
 // Test if we can parse by lane q-metrics
 TEST(q_by_lane_metrics_test, test_convert_write_read)
 {
     metric_set<q_metric> metrics;
-    std::istringstream fin(q_v4::binary_data());
-    illumina::interop::io::read_metrics(fin, metrics);
+    io::read_interop_from_string(q_v4::binary_data(),
+                                 metrics);
 
 
     metric_set<q_by_lane_metric> expected_metric_set;
@@ -40,8 +40,8 @@ TEST(q_by_lane_metrics_test, test_convert_write_read)
     illumina::interop::io::write_metrics(fout, expected_metric_set);
 
     metric_set<q_by_lane_metric> actual_metric_set;
-    std::istringstream iss(fout.str());
-    illumina::interop::io::read_metrics(iss, actual_metric_set);
+    io::read_interop_from_string(fout.str(),
+                                 actual_metric_set);
 
 
     EXPECT_EQ(actual_metric_set.version(), expected_metric_set.version());
@@ -67,8 +67,8 @@ TEST(run_metrics_q_by_lane_test, test_is_group_empty)
 {
     run_metrics metrics;
     EXPECT_TRUE(metrics.is_group_empty(constants::QByLane));
-    std::istringstream fin(q_v4::binary_data());
-    io::read_metrics(fin, metrics.get_set<q_metric>());
+    io::read_interop_from_string(q_v4::binary_data(),
+                                 metrics.get_set<q_metric>());
     logic::metric::create_q_metrics_by_lane(metrics.get_set<q_metric>(), metrics.get_set<q_by_lane_metric>());
     EXPECT_FALSE(metrics.is_group_empty(constants::QByLane));
 }

--- a/src/tests/interop/metrics/q_collapsed_metrics_test.cpp
+++ b/src/tests/interop/metrics/q_collapsed_metrics_test.cpp
@@ -57,7 +57,8 @@ TEST(q_collapsed_metrics_test, test_convert_write_read)
 {
     metric_set<q_metric> metrics;
     std::istringstream fin(q_v4::binary_data());
-    illumina::interop::io::read_metrics(fin, metrics);
+    io::read_interop_from_string(q_v4::binary_data(),
+                                 metrics);
 
 
     metric_set<q_collapsed_metric> expected_metric_set;
@@ -67,8 +68,8 @@ TEST(q_collapsed_metrics_test, test_convert_write_read)
     illumina::interop::io::write_metrics(fout, expected_metric_set);
 
     metric_set<q_collapsed_metric> actual_metric_set;
-    std::istringstream iss(fout.str());
-    illumina::interop::io::read_metrics(iss, actual_metric_set);
+    io::read_interop_from_string(fout.str(),
+                                 actual_metric_set);
 
 
     EXPECT_EQ(actual_metric_set.version(), expected_metric_set.version());
@@ -92,8 +93,8 @@ TEST(run_metrics_q_collapsed_test, test_is_group_empty)
 {
     run_metrics metrics;
     EXPECT_TRUE(metrics.is_group_empty(constants::QCollapsed));
-    std::istringstream fin(q_v4::binary_data());
-    io::read_metrics(fin, metrics.get_set<q_metric>());
+    io::read_interop_from_string(q_v4::binary_data(),
+                                 metrics.get_set<q_metric>());
     logic::metric::create_collapse_q_metrics(metrics.get_set<q_metric>(), metrics.get_set<q_collapsed_metric>());
     EXPECT_FALSE(metrics.is_group_empty(constants::QCollapsed));
 }

--- a/src/tests/interop/metrics/q_metrics_test.cpp
+++ b/src/tests/interop/metrics/q_metrics_test.cpp
@@ -118,8 +118,8 @@ TEST(run_metrics_q_test, test_is_group_empty)
 {
     run_metrics metrics;
     EXPECT_TRUE(metrics.is_group_empty(constants::Q));
-    std::istringstream fin(q_v4::binary_data());
-    io::read_metrics(fin, metrics.get_set<q_metric>());
+    io::read_interop_from_string(q_v4::binary_data(),
+                                 metrics.get_set<q_metric>());
     EXPECT_FALSE(metrics.is_group_empty(constants::Q));
 }
 

--- a/src/tests/interop/metrics/summary_metrics_test.cpp
+++ b/src/tests/interop/metrics/summary_metrics_test.cpp
@@ -182,10 +182,10 @@ TEST(index_summary_test, lane_summary)
     model::metrics::run_metrics metrics(index_v1::run_info());
     try
     {
-        std::istringstream fin1(index_v1::binary_data());
-        illumina::interop::io::read_metrics(fin1, metrics.get_set<model::metrics::index_metric>());
-        std::istringstream fin2(tile_v2::binary_data());
-        illumina::interop::io::read_metrics(fin2, metrics.get_set<model::metrics::tile_metric>());
+        io::read_interop_from_string(index_v1::binary_data(),
+                                     metrics.get_set<index_metric>());
+        io::read_interop_from_string(tile_v2::binary_data(),
+                                     metrics.get_set<tile_metric>());
     }
     catch (const std::exception &) { }
     logic::summary::summarize_index_metrics(metrics, actual);

--- a/src/tests/interop/metrics/tile_metrics_test.cpp
+++ b/src/tests/interop/metrics/tile_metrics_test.cpp
@@ -205,8 +205,8 @@ TEST(run_metrics_tile_test, test_is_group_empty)
 {
     run_metrics metrics;
     EXPECT_TRUE(metrics.is_group_empty(constants::Tile));
-    std::istringstream fin(tile_v2::binary_data());
-    io::read_metrics(fin, metrics.get_set<tile_metric>());
+    io::read_interop_from_string(tile_v2::binary_data(),
+                                 metrics.get_set<tile_metric>());
     EXPECT_FALSE(metrics.is_group_empty(constants::Tile));
 }
 


### PR DESCRIPTION
This changeset enhances the loading speed of InterOps with block reads. It also fixes a minor bug when using vector::front.
