### PR TITLE
Remove Python library from module dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     env: DEPLOY_BUILD=true SCRIPT="bash ./tools/package_osx.sh $PWD 3.5.1 $PWD/dist travis"
   - os: osx
     compiler: clang
-    env: DEPLOY_BUILD=true SCRIPT="bash ./tools/package_osx.sh $PWD 3.6.0b1 $PWD/dist travis"
+    env: DEPLOY_BUILD=true SCRIPT="bash ./tools/package_osx.sh $PWD 3.6.0 $PWD/dist travis"
   - os: osx
     compiler: clang
     env: DEPLOY_BUILD=true SCRIPT="bash ./tools/package_osx.sh $PWD 2.7.11 $PWD/dist travis"
@@ -138,11 +138,11 @@ deploy:
   skip_cleanup: true
   provider: releases
   api_key:
-    secure: "EefkqiGLBE+vHGyLIS5/VvmHPSnJCVKuUlS4+9A+7zg7uWscr7UOmyO/Fwo/RbmrCR7KV02/c9J8hiUiKcjs4ne0m65NtsT8mo7mDQCMwqGtgfBukVvi1C0AdD2g/ztAG/KMkhfk5WTTkSn3LkLy5R2P2cZ4RMfuALyJfUw9Xhs/2CK2RnTgtyKeDjwT1WaB7EoWB0wSPoDJVZR8AeygZNRwaDde20V8pax2+e4MXQh9d0Wj0lO4VpnFQp0TrvTQPKZKrYYeMIdR2e8HAG++xLMsZ4T5SYA3EuDQjyLP5rb1AE1IBbrd4tcUh/0sURQ+uR7y32eGErCQ/+JnrLGnH2xZklh9PYHaV4gkseJJpcnhko11HzxEuWfRj4qGZrMkmq3DdrGCsCGA+MnsT0oTqiexuOKWvpSLAJATeco1yOSoJ6IYvi2tYTJYMxzsPtOMcvAhi1MBpuyZeRIygGgz7wD2tysTVLRUYTVL25f7sVBvz9BpPQGdRtuDLVTnu8b1hS5w9vLncrNnxk+dlCYufzoTmwJ4D3IsL5kXl9/DrgDlkxfIz5/R4iA/vDccGvqdklBk47fW3pF9ATxUMIw86USlRbb0yecSTgNsqd+Si0RKwJ7Jchpj0CPeiKIoMXChxnOOJesY4ROhhpCqVif2LBN8w5yt4B4gHJ9T0TY6k1E="
+    secure: qUB+Gaq1jYzYgMW+rh3mYquzFpt4cuJ+C89L0o/NkkSrCeDizftNL0P2mBXMqeUOLEWDFGwMgWcdTSs0MMdoOmYKp0hMFbCzipbwANKdzcmUjYx9VDlft9iEnKyjhnwLTyljvcK2OYWMCiPkTv+V4O0H9/T8bZEGQ/zBElCeYJPSdjNTRSFzfe8XqzGsNoty4YDlK89UIWy2Pmw38qRIWpu2rk3WAMDxsJgSO7uPs5xxaLioAfukhV7thbeQjYQn42OQ8eA2AwQa478KtlY2V5XtZqFQtdDPosvtS5HXYCXvnCWJeUbB0KrE5o+Je8njm4e+K30WDfpDGiCPU7Guz52FN551/5L5iv0+6++ZOt8fxKSMF+4H42JxDzDMdzvJmTImdIP2ACm5EnY8pJXOVnXbemDNNnpjhE8CqMVSqfiB+QDLasiZ3PBAaqPbb7XVYKpxUE1nGQCIynHjS7KClKo0EKrvJo2vWSgeXW5wBtmGuIsgMkPcNTtqM6WEui1mdoKQXrvAl4SxdgwhvmA6RYhva+yBIGf9HPqfGL7c2ByQADULLtc8SgOjqbibDO+jVITTtWsliaD53nXJKHzU8JkOsAJNl0Le+kyQKNoHaMersHrZzccrCeRkGOES5g/a+2a3PF0hRkgQjmVQsEEPw9C1rLEXG5gTUL3gd5UmD58=
   file_glob: true
   file: $PWD/dist/*.*
   on:
-    repo: ezralanglois/interop
+    repo: Illumina/interop
     branch: master
     tags: true
     condition:

--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -1,10 +1,16 @@
 # Changes                                               {#changes}
 
-## v1.0.24 (Master)
+## v1.0.25 (Master)
 
 Date       | Description
 ---------- | -----------
 0000-00-00 | placeholder
+
+## v1.0.24
+
+Date       | Description
+---------- | -----------
+2017-05-05 | Remove Python library from module dependencies
 
 ## v1.0.23
 

--- a/src/apps/inc/application.h
+++ b/src/apps/inc/application.h
@@ -67,6 +67,10 @@ inline int read_run_metrics(const char* filename,
         std::cerr << ex.what() << std::endl;
         return BAD_FORMAT;
     }
+    catch(const model::invalid_run_info_cycle_exception& ex)
+    {
+        std::cerr << ex.what() << std::endl;
+    }
     catch(const std::exception& ex)
     {
         std::cerr << ex.what() << std::endl;

--- a/src/ext/python/CMakeLists.txt
+++ b/src/ext/python/CMakeLists.txt
@@ -46,10 +46,6 @@ if(CMAKE_COMPILER_IS_GNUCC AND ENABLE_PORTABLE)
 endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-    #-flat_namespace -undefined suppress
-    set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
-    set(CMAKE_SHARED_LIBRARY_CREATE_LINKER_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -undefined dynamic_lookup")
     set(PYTHON_GENERATED_LINK_FLAGS "-undefined dynamic_lookup")
 endif()
 

--- a/src/tests/interop/inc/abstract_regression_test_generator.h
+++ b/src/tests/interop/inc/abstract_regression_test_generator.h
@@ -10,6 +10,7 @@
 #include "src/tests/interop/inc/regression_test_data.h"
 #include "src/tests/interop/inc/generic_fixture.h"
 #include "src/tests/interop/inc/proxy_parameter_generator.h"
+#include "interop/model/run_metrics.h"
 
 namespace illumina{ namespace interop { namespace unittest
 {
@@ -149,7 +150,18 @@ namespace illumina{ namespace interop { namespace unittest
         std::string m_test_dir;
     };
 
-
+    /** Read run metrics safely from the disk
+     *
+     * @param metrics run_metrics object
+     * @param run_folder path to the run folder
+     */
+    inline void read_metrics_safe(model::metrics::run_metrics& metrics, const std::string& run_folder)
+    {
+        try{
+            metrics.read(run_folder);
+        }
+        catch(const model::invalid_run_info_cycle_exception&){}
+    }
 
 }}}
 

--- a/src/tests/interop/logic/imaging_table_regression_test.cpp
+++ b/src/tests/interop/logic/imaging_table_regression_test.cpp
@@ -192,7 +192,7 @@ protected:
     bool generate_actual(const std::string& run_folder,  model::table::imaging_table& actual)const
     {
         model::metrics::run_metrics actual_metrics;
-        actual_metrics.read(run_folder);
+        read_metrics_safe(actual_metrics, run_folder);
         if( actual_metrics.empty() ) return false;
         logic::table::create_imaging_table(actual_metrics, actual);
         return actual.column_count()*actual.row_count() > 0;

--- a/src/tests/interop/logic/inc/plot_regression_test_generator.h
+++ b/src/tests/interop/logic/inc/plot_regression_test_generator.h
@@ -153,7 +153,7 @@ namespace illumina { namespace interop { namespace unittest
             if( current != run_folder )
             {
                 current = run_folder;
-                actual_metrics.read(run_folder);
+                read_metrics_safe(actual_metrics, run_folder);
             }
 
             return actual_metrics;

--- a/src/tests/interop/logic/index_summary_test.cpp
+++ b/src/tests/interop/logic/index_summary_test.cpp
@@ -300,7 +300,7 @@ protected:
     bool generate_actual(const std::string &run_folder, model::summary::index_flowcell_summary &actual) const
     {
         model::metrics::run_metrics actual_metrics;
-        actual_metrics.read(run_folder);
+        read_metrics_safe(actual_metrics, run_folder);
         if( actual_metrics.empty() ) return false;
         logic::summary::summarize_index_metrics(actual_metrics, actual);
         return actual.size() > 0;

--- a/src/tests/interop/logic/summary_metrics_test.cpp
+++ b/src/tests/interop/logic/summary_metrics_test.cpp
@@ -670,7 +670,7 @@ protected:
     bool generate_actual(const std::string &run_folder, model::summary::run_summary &actual) const
     {
         model::metrics::run_metrics actual_metrics;
-        actual_metrics.read(run_folder);
+        read_metrics_safe(actual_metrics, run_folder);
         if( actual_metrics.empty() ) return false;
         Logic logic;
         logic(actual_metrics, actual);

--- a/src/tests/interop/metrics/metric_regression_tests.cpp
+++ b/src/tests/interop/metrics/metric_regression_tests.cpp
@@ -75,7 +75,7 @@ protected:
      */
     bool generate_actual(const std::string &run_folder, model::metrics::run_metrics &actual) const
     {
-        actual.read(run_folder);
+        read_metrics_safe(actual, run_folder);
         return true;
     }
 

--- a/tools/package_osx.sh
+++ b/tools/package_osx.sh
@@ -30,9 +30,11 @@ else
 fi
 
 echo "Install Python ${PYTHON_VER}..." && echo -en "${TRAVIS_BEG}"
-brew install pyenv && true
-pyenv install ${PYTHON_VER} && true
-pyenv local ${PYTHON_VER}
+brew unlink pyenv
+brew install pyenv
+export PATH=$(pyenv root)/shims:${PATH}
+pyenv install ${PYTHON_VER}
+pyenv global ${PYTHON_VER}
 which python
 echo -en ${TRAVIS_END}
 python --version


### PR DESCRIPTION
The Mac OSX Python wheels were being linked to the Python shared library. This resulted in wheels that only worked with the build Python (in this case Anaconda).

This fixes the issue by forcing the clang linker to use dynamic lookup for symbols in the Python Library.

This resolves #127