### PR TITLE
Travis deployment broke with a warning. The fix broke it further

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -160,4 +160,5 @@ deploy:
       tags: true
       condition:
       - "$DEPLOY_DOCS == true"
+  - edge: true
 

--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -1,11 +1,17 @@
 # Changes                                               {#changes}
+ 
+## v1.1.14
+
+Date       | Description
+---------- | -----------
+2020-11-09 | Travis deployment broke with a warning. The fix broke it further
 
 
 ## v1.1.13
 
 Date       | Description
 ---------- | -----------
-2020-08-25 | Issue-322: Update RunParameters.xml parsing to support iSeq and NextSeq2k
+2020-11-06 | Issue-322: Update RunParameters.xml parsing to support iSeq and NextSeq2k
 
 
 ## v1.1.12


### PR DESCRIPTION
This will hopefully fix it. Merging is the only way to tell for sure

Docs for fix: https://docs.travis-ci.com/user/deployment-v2
Description of original issues: https://travis-ci.community/t/skip-cleanup-true-is-now-deprecated-how-to-go-for-gradle-publish/6641