### PR TITLE
Partial revert for travis-ci deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,6 +141,7 @@ before_deploy:
 
 deploy:
   - provider: releases
+    skip_cleanup: true
     api_key: $GITHUB_TOKEN
     file_glob: true
     file: $PWD/dist/*.*
@@ -151,7 +152,7 @@ deploy:
       condition:
         - "$DEPLOY_BUILD == true"
   - provider: pages
-    skip-cleanup: true
+    skip_cleanup: true
     github-token: $GITHUB_TOKEN
     local_dir: $PWD/dist/html
     on:
@@ -160,5 +161,4 @@ deploy:
       tags: true
       condition:
       - "$DEPLOY_DOCS == true"
-  - edge: true
 


### PR DESCRIPTION
Still having trouble getting Travis-CI builds to deploy. 

Setting edge to true just broke a number of travis builds. I will remove the requirement that travis passes, and wait until they fix the mess they have created.

This revert should get the individual tests to pass, but the overall may still fail due to the deprecation warnings