### PR TITLE
Support % loading concentration for NextSeq 1k/2k (P3 release)

### DIFF
--- a/docs/src/binary_formats.md
+++ b/docs/src/binary_formats.md
@@ -44,6 +44,7 @@ The documentation for the model notes when an attribute is only populated by a s
  - @subpage q_collapsed_v4 "Collapsed Q-Metrics Version 4"
  - @subpage q_collapsed_v5 "Collapsed Q-Metrics Version 5"
  - @subpage q_collapsed_v6 "Collapsed Q-Metrics Version 6"
+ - @subpage summary_run_v1 "Summary Run Version 1"
  
  The following are binary formats used only for testing purposes and are not officially supported:
  

--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -1,5 +1,13 @@
 # Changes                                               {#changes}
- 
+
+## v1.1.15
+
+Date       | Description
+---------- | -----------
+2020-08-26 | Issue-229: Support % loading concentration
+2020-08-26 | Issue-229: Fix Python binding for read_metrics_from_buffer
+
+
 ## v1.1.14
 
 Date       | Description

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,6 +58,7 @@ List of InterOp Metric Files
 | [QMetricsByLaneOut.bin]          | Per tile per cycle Q-score histogram per lane                                     |
 | [EmpiricalPhasingMetricsOut.bin] | Phasing weights per tile per cycle                                                |
 | [ExtendedTileMetricsOut.bin]     | Per tile occupancy metrics                                                        |
+| [SummaryRunMetricsOut.bin]       | Per run summary metrics                                                           |
 
 [CorrectedIntMetricsOut.bin]: @ref corrected_intensity "CorrectedIntMetricsOut.bin"
 [ErrorMetricsOut.bin]: @ref error_metric "ErrorMetricsOut.bin"
@@ -70,6 +71,7 @@ List of InterOp Metric Files
 [QMetricsByLaneOut.bin]: @ref q_metric_by_lane "QMetricsByLaneOut.bin"
 [EmpiricalPhasingMetricsOut.bin]: @ref phasing_metric "EmpiricalPhasingMetricOut.bin"
 [ExtendedTileMetricsOut.bin]: @ref extended_tile_metric "ExtendedTileMetricsOut.bin"
+[SummaryRunMetricsOut.bin]: @ref summary_run_metric "SummaryRunMetricsOut.bin"
 
 
 Known Limitations

--- a/interop/constants/enums.h
+++ b/interop/constants/enums.h
@@ -14,7 +14,7 @@
 #include "interop/util/cstdint.h"
 
 /** Sentinel for an unknown enum type */
-#define INTEROP_UNKNOWN 0x400
+#define INTEROP_UNKNOWN 0x800
 
 
 /** Enumeration of specific features that can belong to a metric
@@ -30,6 +30,7 @@
         INTEROP_TUPLE_ASSIGN(BaseFeature, 0x08), \
         INTEROP_TUPLE_ASSIGN(ChannelFeature, 0x10), \
         INTEROP_TUPLE_ASSIGN(LaneFeature, 0x20), \
+        INTEROP_TUPLE_ASSIGN(DiskFeature, 0x400), \
         INTEROP_TUPLE1(UnknownMetricFeature)
 //NOTE: if we add any more features above, we should update the unknown metric value below
 
@@ -74,18 +75,19 @@
  * @see illumina::interop::constants::metric_group
  */
 #define INTEROP_ENUM_METRIC_GROUPS \
-        INTEROP_TUPLE2(CorrectedInt, CycleFeature|BaseFeature), \
-        INTEROP_TUPLE2(Error, CycleFeature), \
-        INTEROP_TUPLE2(Extraction, CycleFeature|ChannelFeature), \
-        INTEROP_TUPLE2(Image, CycleFeature|ChannelFeature), \
-        INTEROP_TUPLE2(Index, ReadFeature), \
-        INTEROP_TUPLE2(Q, CycleFeature), \
-        INTEROP_TUPLE2(Tile, TileFeature), \
+        INTEROP_TUPLE2(CorrectedInt, CycleFeature|BaseFeature|DiskFeature), \
+        INTEROP_TUPLE2(Error, CycleFeature|DiskFeature), \
+        INTEROP_TUPLE2(Extraction, CycleFeature|ChannelFeature|DiskFeature), \
+        INTEROP_TUPLE2(Image, CycleFeature|ChannelFeature|DiskFeature), \
+        INTEROP_TUPLE2(Index, ReadFeature|DiskFeature), \
+        INTEROP_TUPLE2(Q, CycleFeature|DiskFeature), \
+        INTEROP_TUPLE2(Tile, TileFeature|DiskFeature), \
         INTEROP_TUPLE2(QByLane, LaneFeature), \
         INTEROP_TUPLE2(QCollapsed, CycleFeature), \
-        INTEROP_TUPLE2(EmpiricalPhasing, CycleFeature), \
+        INTEROP_TUPLE2(EmpiricalPhasing, CycleFeature|DiskFeature), \
         INTEROP_TUPLE2(DynamicPhasing, CycleFeature), \
-        INTEROP_TUPLE2(ExtendedTile, TileFeature), \
+        INTEROP_TUPLE2(ExtendedTile, TileFeature|DiskFeature), \
+        INTEROP_TUPLE2(SummaryRun, DiskFeature), \
         INTEROP_TUPLE1(MetricCount),\
         INTEROP_TUPLE1(UnknownMetricGroup)
 
@@ -187,6 +189,8 @@
         INTEROP_TUPLE1(BaseReadType),\
         /** Lane base types are written out once for each lane and cycle */\
         INTEROP_TUPLE1(BaseLaneType),\
+        /** Run base types are written out once per run */\
+        INTEROP_TUPLE1(BaseRunType), \
         INTEROP_TUPLE1(BaseMetricCount),\
         INTEROP_TUPLE1(UnknownBaseType)
 

--- a/interop/constants/typedefs.h
+++ b/interop/constants/typedefs.h
@@ -22,6 +22,8 @@ namespace illumina { namespace interop { namespace constants
     typedef constant_type<metric_base_type, BaseReadType> base_read_t;
     /** Define base type for lane metrics */
     typedef constant_type<metric_base_type, BaseLaneType> base_lane_t;
+    /** Define base type for lane metrics */
+    typedef constant_type<metric_base_type, BaseRunType> base_run_t;
 
 }}}
 

--- a/interop/io/format/metric_format.h
+++ b/interop/io/format/metric_format.h
@@ -288,7 +288,6 @@ namespace illumina { namespace interop { namespace io
                 else
                 {
                     const size_t offset = metric_offset_map[metric.id()];
-                    INTEROP_ASSERTMSG(metric_set[offset].lane() != 0, offset);
                     count += Layout::map_stream(in, metric_set[offset], metric_set, false);
                     INTEROP_ASSERT(metric_set[offset].id()>0);
                 }

--- a/interop/io/layout/base_metric.h
+++ b/interop/io/layout/base_metric.h
@@ -25,6 +25,53 @@ namespace illumina { namespace interop { namespace io { namespace layout
 {
 #pragma pack(1)
 
+    /** Empty class for InterOp records that contain run specific metrics
+     *
+     * These records contain both a lane and tile identifier.
+     *
+     * @note These classes are packed such that there is not padding. Their size reflects the accumulation of their
+     * member fields.
+     */
+    struct base_run_metric
+    {
+        /** Lane integral type */
+        typedef ::uint16_t lane_t;
+        /** Tile integral type */
+        typedef ::uint32_t tile_t;
+        /** Define a record size type */
+        typedef ::uint8_t record_size_t;
+        /** Define base type */
+        typedef constants::base_run_t base_t;
+
+        /** Constructor
+         */
+        base_run_metric() : m_dummy(0)
+        {
+        }
+
+        /** Set the lane and tile id from a base metric
+         *
+         * @param metric a base_metric from the model
+         */
+        template<class BaseMetric>
+        void set(const BaseMetric &/*metric*/)
+        {
+            m_dummy = 0;
+        }
+
+        /** Test if the layout contains valid data
+         *
+         * @return true if data is valid
+         */
+        bool is_valid() const
+        {
+            return true;
+        }
+
+    private:
+        lane_t m_dummy;
+    };
+
     /** Base class for InterOp records that contain tile specific metrics
      *
      * These records contain both a lane and tile identifier.

--- a/interop/io/metric_file_stream.h
+++ b/interop/io/metric_file_stream.h
@@ -41,14 +41,14 @@ namespace illumina { namespace interop { namespace io
      * @return number of bytes written
      */
     template<class MetricSet>
-    size_t write_interop_to_buffer(const MetricSet& metrics, ::uint8_t* buffer, size_t buffer_size)
+    size_t write_interop_to_buffer(const MetricSet& metrics, ::uint8_t* buffer, const size_t buffer_size)
                         INTEROP_THROW_SPEC((io::invalid_argument, io::bad_format_exception, io::incomplete_file_exception, io::format_exception))
     {
         std::ostringstream fout;
         write_metrics(fout, metrics, metrics.version());
         std::string str = fout.str();
         if(buffer_size < str.length())
-            INTEROP_THROW(invalid_argument, "Buffer size too small");
+            INTEROP_THROW(invalid_argument, "Buffer size too small: " << buffer_size << " < " << str.length());
         size_t i=0;
         for(;i<str.length();++i)
             buffer[i] = static_cast< ::uint8_t >(str[i]);
@@ -63,7 +63,7 @@ namespace illumina { namespace interop { namespace io
      * @throw incomplete_file_exception
      */
     template<class MetricSet>
-    void read_interop_from_buffer(::uint8_t* buffer, size_t buffer_size, MetricSet& metrics)  INTEROP_THROW_SPEC(
+    void read_interop_from_buffer(::uint8_t* buffer, const size_t buffer_size, MetricSet& metrics)  INTEROP_THROW_SPEC(
                                                                             (interop::io::file_not_found_exception,
                                                                             interop::io::bad_format_exception,
                                                                             interop::io::incomplete_file_exception,

--- a/interop/logic/summary/summary_statistics.h
+++ b/interop/logic/summary/summary_statistics.h
@@ -148,6 +148,7 @@ namespace illumina { namespace interop { namespace logic { namespace summary
     template<typename I, typename S>
     void summarize(I beg, I end, S &stat, const bool skip_median)
     {
+        stat.clear();
         if (beg == end) return;
         stat.mean(util::mean<float>(beg, end));
         stat.stddev(std::sqrt(util::variance_with_mean<float>(beg, end, stat.mean())));
@@ -194,6 +195,31 @@ namespace illumina { namespace interop { namespace logic { namespace summary
         stat.stddev(std::sqrt(util::variance_with_mean<float>(beg, end, stat.mean(), op)));
         if(!skip_median) stat.median(util::median_interpolated<float>(beg, end, comp, op));
         return size_t(std::distance(beg, end));
+    }
+
+    /** Calculate the sum over a collection of values, ignoring NaNs
+     *
+     * @param beg iterator to start of collection
+     * @param end iterator to end of collection
+     * @param init initial value for accumulate call
+     * @param op unary/binary operator for getting a value in a complex object
+     * @return sum of init + applying op to the range [beg, end)
+     */
+    template<typename I, typename S, typename Op>
+    S nan_accumulate(I beg, I end, const S init, Op op)
+    {
+        S return_value = init;
+        if (beg == end) return init;
+        const float temp_value = 0;
+        for (; beg != end; ++beg)
+        {
+            const float current_value = op(temp_value, *beg);
+            if(!std::isnan(current_value))
+            {
+                return_value += static_cast<S>(current_value);
+            }
+        }
+        return return_value;
     }
 
     /** Safe divide

--- a/interop/logic/summary/tile_summary.h
+++ b/interop/logic/summary/tile_summary.h
@@ -89,16 +89,16 @@ namespace illumina { namespace interop { namespace logic { namespace summary
                   util::op::const_member_function_less(&model::metrics::tile_metric::percent_pf),
                   skip_median);
         stat_summary.percent_pf(stat);
-        stat_summary.reads(std::accumulate(tile_data.begin(),
+        stat_summary.reads(nan_accumulate(tile_data.begin(),
                                            tile_data.end(),
-                                           float(0),
+                                          float(0),
                                            util::op::const_member_function(
                                                    &model::metrics::tile_metric::cluster_count)));
-        stat_summary.reads_pf(std::accumulate(tile_data.begin(),
-                                              tile_data.end(),
-                                              float(0),
-                                              util::op::const_member_function(
-                                                      &model::metrics::tile_metric::cluster_count_pf)));
+        stat_summary.reads_pf(nan_accumulate(tile_data.begin(),
+                                             tile_data.end(),
+                                             float(0),
+                                             util::op::const_member_function(
+                                                     &model::metrics::tile_metric::cluster_count_pf)));
     }
     /** Update the stat summary with cached read metrics
      *

--- a/interop/model/metric_base/base_metric.h
+++ b/interop/model/metric_base/base_metric.h
@@ -25,6 +25,7 @@ namespace illumina { namespace interop { namespace model { namespace metric_base
 
     // Forward declaration
     class base_metric;
+    class empty_metric;
 
     /** Get attributes of the metric */
     template<class Metric>
@@ -58,7 +59,7 @@ namespace illumina { namespace interop { namespace model { namespace metric_base
          *
          * @todo remove this method
          */
-        void update_max_cycle(const base_metric &)
+        void update_max_cycle(const empty_metric &)
         { }
     };
 
@@ -68,6 +69,58 @@ namespace illumina { namespace interop { namespace model { namespace metric_base
      */
     class empty_metric
     {
+    public:
+        /** id_t type */
+        typedef ::uint32_t id_t;
+        /** Unsigned int
+         */
+        typedef ::uint32_t uint_t;
+        /** Define the base type */
+        typedef constants::base_run_t base_t;
+
+    public:
+        /** Set the base metric identifiers
+         *
+         * @param base layout base
+         */
+        template<class BaseMetric>
+        void set_base(const BaseMetric &/*base*/)
+        {
+        }
+        /** Set id
+         *
+         * @param lane lane number
+         * @param tile tile number
+         */
+        void set_base(const uint_t /*lane*/, const uint_t /*tile*/)
+        {
+        }
+        /** Get the metric name suffix
+         *
+         * @return empty string
+         */
+        static const char *suffix()
+        {
+            return "";
+        }
+
+        /** Comparison operator used to sort the entries in order of their IDs
+         *
+         * @param metric2 metric to compare with the current object
+         * @return true if this object's ID is less than metric2's ID
+         */
+        bool operator< (const empty_metric& /*metric2*/) const
+        {
+            return false;
+        }
+        /** Unique id created from both the lane and tile
+         *
+         * @return 1
+         */
+        static id_t create_id(const id_t, const id_t, const id_t= 0)// TODO: remove hack (const id_t=0)
+        {
+            return 1;// Cannot be zero
+        }
     };
 
     /** Base class for InterOp classes that contain tile specific metrics

--- a/interop/model/metrics/summary_run_metric.h
+++ b/interop/model/metrics/summary_run_metric.h
@@ -1,0 +1,212 @@
+/** Summary run metric
+ *
+ * The summary run metric contains run-level summary information
+ *
+ *  @file
+ *  @date 07/06/2020
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#pragma once
+
+#include "interop/io/format/generic_layout.h"
+#include "interop/model/metric_base/base_metric.h"
+#include "interop/model/metric_base/metric_set.h"
+
+namespace illumina { namespace interop { namespace model { namespace metrics
+{
+
+    /** Summary run metric
+     *
+     * The summary run metric contains run-level summary information
+     *
+     * @note Supported versions: 1
+     */
+    class summary_run_metric : public metric_base::empty_metric
+    {
+    public:
+        enum
+        {
+            /** Unique type code for metric */
+            TYPE = constants::SummaryRun,
+            /** Latest version of the InterOp format */
+            LATEST_VERSION = 1
+        };
+        /** Static run metric header */
+        typedef metric_base::base_metric_header header_type;
+        /** Vector of floats */
+        typedef std::vector<float> float_vector;
+        /** ubyte_t type */
+        typedef uint8_t ubyte_t;
+        /** ushort_t type */
+        typedef uint16_t ushort_t;
+        /** uint_t type */
+        typedef uint32_t uint_t;
+        /** Count type */
+        typedef double count_t;
+
+    public:
+        /** Constructor */
+        summary_run_metric() :
+                m_occupancy_proxy_cluster_count(missing())
+                , m_raw_cluster_count(missing())
+                , m_occupied_cluster_count(missing())
+                , m_pf_cluster_count(missing())
+        { }
+        /** Constructor */
+        summary_run_metric(const header_type&) :
+                m_occupancy_proxy_cluster_count(missing())
+                , m_raw_cluster_count(missing())
+                , m_occupied_cluster_count(missing())
+                , m_pf_cluster_count(missing())
+        { }
+
+        /** Constructor
+         *
+         * @note Version 1
+         * @param occupancy_proxy_cluster_count proxy for occupancy
+         * @param raw_cluster_count raw cluster count
+         * @param occupied_cluster_count occupied cluster count
+         * @param pf_cluster_count pf cluster count
+         */
+        summary_run_metric(const count_t occupancy_proxy_cluster_count
+                , const count_t raw_cluster_count
+                , const count_t occupied_cluster_count
+                , const count_t pf_cluster_count
+                ) :
+                m_occupancy_proxy_cluster_count(occupancy_proxy_cluster_count)
+                , m_raw_cluster_count(raw_cluster_count)
+                , m_occupied_cluster_count(occupied_cluster_count)
+                , m_pf_cluster_count(pf_cluster_count)
+        {}
+
+    public:
+        /** Setter
+        *
+        * @note Version 1
+        * @param occupancy_proxy_cluster_count proxy for occupancy
+        * @param raw_cluster_count raw cluster count
+        * @param occupied_cluster_count occupied cluster count
+        * @param pf_cluster_count pf cluster count
+        */
+        void set(const count_t occupancy_proxy_cluster_count
+                , const count_t raw_cluster_count
+                , const count_t occupied_cluster_count
+                , const count_t pf_cluster_count)
+        {
+            m_occupancy_proxy_cluster_count = occupancy_proxy_cluster_count;
+            m_raw_cluster_count = raw_cluster_count;
+            m_occupied_cluster_count = occupied_cluster_count;
+            m_pf_cluster_count = pf_cluster_count;
+        }
+
+        /** @defgroup summary_run_metric Run distortion metric
+         *
+         * Run summary metrics
+         *
+         * @ref illumina::interop::model::metrics::summary_run_metric "See full class description"
+         * @ingroup run_metrics
+         * @{
+         */
+        /** Return raw cluster count
+         *
+         *  @return raw cluster count
+         */
+        count_t raw_cluster_count() const
+        {
+            return m_raw_cluster_count;
+        }
+        /** Return occupancy cluster count
+         *
+         *  @return occupancy cluster count
+         */
+        count_t occupied_cluster_count() const
+        {
+            return m_occupied_cluster_count;
+        }
+        /** Return PF cluster count
+         *
+         *  @return PF cluster count
+         */
+        count_t pf_cluster_count() const
+        {
+            return m_pf_cluster_count;
+        }
+        /** Return occupancy proxy cluster count
+         *
+         *  @return occupancy proxy cluster count
+         */
+        count_t occupancy_proxy_cluster_count() const
+        {
+            return m_occupancy_proxy_cluster_count;
+        }
+        /** Return percent occupancy proxy
+         *
+         *  @return percent occupancy proxy
+         */
+        count_t percent_occupancy_proxy() const
+        {
+            if(std::isnan(m_pf_cluster_count)) return missing();
+            if(std::isnan(m_occupancy_proxy_cluster_count)) return missing();
+            return m_occupancy_proxy_cluster_count / m_pf_cluster_count * 100.0;
+        }
+        /** Return percent PF
+         *
+         *  @return percent PF
+         */
+        count_t percent_pf() const
+        {
+            if(std::isnan(m_raw_cluster_count)) return missing();
+            if(std::isnan(m_pf_cluster_count)) return missing();
+            return m_pf_cluster_count / m_raw_cluster_count * 100.0;
+        }
+        /** Return percent occupancy
+         *
+         *  @return percent occupancy
+         */
+        count_t percent_occupied() const
+        {
+            if(std::isnan(m_raw_cluster_count)) return missing();
+            if(std::isnan(m_occupied_cluster_count)) return missing();
+            return m_occupied_cluster_count / m_raw_cluster_count * 100.0;
+        }
+        /** @} */
+        /** Unique id created from both the lane and tile
+         *
+         * @return unique identifier
+         */
+        id_t id() const
+        {
+            return 1;// There is only ever 1 per run, cannot be zero
+        }
+
+    public:
+        /** Get the prefix of the InterOp filename
+         *
+         * @return prefix
+         */
+        static const char *prefix()
+        { return "SummaryRun"; }
+
+    public:
+        /** Flag if value is missing
+         *
+         * @return missing sentinel
+         */
+        static count_t missing()
+        {
+            return std::numeric_limits<count_t>::quiet_NaN();
+        }
+
+    private:
+        count_t m_occupancy_proxy_cluster_count;
+        count_t m_raw_cluster_count;
+        count_t m_occupied_cluster_count;
+        count_t m_pf_cluster_count;
+
+        template<class MetricType, int Version>
+        friend
+        struct io::generic_layout;
+    };
+}}}}
+

--- a/interop/model/run_metrics.h
+++ b/interop/model/run_metrics.h
@@ -29,6 +29,7 @@
 #include "interop/model/metrics/q_by_lane_metric.h"
 #include "interop/model/metrics/q_collapsed_metric.h"
 #include "interop/model/metrics/tile_metric.h"
+#include "interop/model/metrics/summary_run_metric.h"
 
 namespace illumina { namespace interop { namespace model { namespace metrics
 {
@@ -48,6 +49,7 @@ namespace illumina { namespace interop { namespace model { namespace metrics
      * @see tile_metrics
      * @see q_by_lane_metric
      * @see q_collapsed_metric
+     * @see summary_run_metric
      */
     class run_metrics
     {
@@ -65,7 +67,8 @@ namespace illumina { namespace interop { namespace model { namespace metrics
                 q_metric,
                 q_by_lane_metric,
                 q_collapsed_metric,
-                tile_metric
+                tile_metric,
+                summary_run_metric
         >::result_t metric_type_list_t;
 
     private:
@@ -427,7 +430,7 @@ namespace illumina { namespace interop { namespace model { namespace metrics
          * @param buffer_size size of binary buffer
          */
         void read_metrics_from_buffer(const constants::metric_group group,
-                                     uint8_t* buffer,
+                                     ::uint8_t* buffer,
                                      const size_t buffer_size) INTEROP_THROW_SPEC((
         io::file_not_found_exception,
         io::bad_format_exception,
@@ -440,7 +443,7 @@ namespace illumina { namespace interop { namespace model { namespace metrics
          * @param buffer_size size of binary buffer
          */
         void write_metrics_to_buffer(const constants::metric_group group,
-                                     uint8_t* buffer,
+                                     ::uint8_t* buffer,
                                      const size_t buffer_size)const INTEROP_THROW_SPEC((
         io::invalid_argument,
         io::bad_format_exception,

--- a/interop/model/summary/metric_summary.h
+++ b/interop/model/summary/metric_summary.h
@@ -26,7 +26,8 @@ namespace illumina { namespace interop { namespace model { namespace summary {
                 m_percent_gt_q30(std::numeric_limits<float>::quiet_NaN()),
                 m_yield_g(std::numeric_limits<float>::quiet_NaN()),
                 m_projected_yield_g(0),
-                m_percent_occupied(std::numeric_limits<float>::quiet_NaN())
+                m_percent_occupied(std::numeric_limits<float>::quiet_NaN()),
+                m_percent_occupancy_proxy(std::numeric_limits<float>::quiet_NaN())
 
         {}
     public:
@@ -103,6 +104,16 @@ namespace illumina { namespace interop { namespace model { namespace summary {
         {
             return m_percent_occupied;
         }
+        /** Get the percent occupancy proxy
+         *
+         * Also known as % loading concentration
+         *
+         * @return percent occupancy proxy
+         */
+        float percent_occupancy_proxy()const
+        {
+            return m_percent_occupancy_proxy;
+        }
         /** @} */
         /** Set the first cycle intensity
          *
@@ -161,6 +172,16 @@ namespace illumina { namespace interop { namespace model { namespace summary {
         {
             m_percent_occupied = val;
         }
+        /** Set the percent occupancy proxy
+         *
+         * Also known as % loading concentration
+         *
+         * @param val percent occupancy proxy
+         */
+        void percent_occupancy_proxy(const float val)
+        {
+            m_percent_occupancy_proxy = val;
+        }
 
         /** Resize the underlying data
          */
@@ -176,6 +197,7 @@ namespace illumina { namespace interop { namespace model { namespace summary {
         float m_yield_g;
         float m_projected_yield_g;
         float m_percent_occupied;
+        float m_percent_occupancy_proxy;
         template<class MetricType, int Version>
         friend struct io::generic_layout;
     };

--- a/interop/model/summary/stat_summary.h
+++ b/interop/model/summary/stat_summary.h
@@ -273,7 +273,6 @@ namespace illumina { namespace interop { namespace model { namespace summary
         }
         /** Get mean summarizing the percent occupied
          *
-         * @note IUO
          * @return statistics summarizing the percent occupied
          */
         const metric_stat_t &percent_occupied() const
@@ -470,7 +469,6 @@ namespace illumina { namespace interop { namespace model { namespace summary
         }
         /** Set mean summarizing the percent occupied
          *
-         * @note IUO
          * @param val statistics summarizing the percent occupied
          */
         void percent_occupied(const metric_stat_t& val)

--- a/interop/util/exception_specification.h
+++ b/interop/util/exception_specification.h
@@ -5,7 +5,7 @@
  *  @file
  *  @date 6/25/18
  *  @version 1.0
- *  @copyright Illumina Use Only
+ *  @copyright GNU Public License.
  */
 #pragma once
 

--- a/interop/util/type_traits.h
+++ b/interop/util/type_traits.h
@@ -31,12 +31,13 @@ namespace illumina { namespace interop
             typename T9=null_type, typename T10=null_type, typename T11=null_type, typename T12=null_type,
             typename T13=null_type, typename T14=null_type, typename T15=null_type, typename T16=null_type,
             typename T17=null_type, typename T18=null_type, typename T19=null_type, typename T20=null_type,
-            typename T21=null_type, typename T22=null_type, typename T23=null_type, typename T24=null_type>
+            typename T21=null_type, typename T22=null_type, typename T23=null_type, typename T24=null_type,
+            typename T25=null_type, typename T26=null_type>
     struct make_type_list
     {
     private:
         typedef typename make_type_list<
-                T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24
+                T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26
         >::result_t tail_result_t;
     public:
         /** List of types */

--- a/src/apps/aggregate.cpp
+++ b/src/apps/aggregate.cpp
@@ -63,6 +63,8 @@ private:
             m_run.get<MetricSet>().insert(metrics[i]);
         }
     }
+    template<class MetricSet>
+    void copy(const MetricSet&, const constants::base_run_t *)const{}
 
 private:
     run_metrics& m_run;

--- a/src/ext/swig/arrays/arrays_numpy_impl.i
+++ b/src/ext/swig/arrays/arrays_numpy_impl.i
@@ -7,8 +7,8 @@
 import_array();
 %}
 
-%apply (unsigned char* INPLACE_ARRAY1, int DIM1) {(::uint8_t* buffer, size_t buffer_size)}
-%apply (unsigned char* INPLACE_ARRAY1, int DIM1) {(unsigned char* buffer, size_t buffer_size)}
+%apply (unsigned char* INPLACE_ARRAY1, int DIM1) {(::uint8_t* buffer, const size_t buffer_size)}
+%apply (unsigned char* INPLACE_ARRAY1, int DIM1) {(unsigned char* buffer, const size_t buffer_size)}
 %apply (float* INPLACE_ARRAY1, int DIM1) {(float* buffer, size_t buffer_size)}
 %apply (unsigned int* INPLACE_ARRAY1, int DIM1) {(::uint32_t* id_buffer, size_t id_buffer_size)}
 %apply (float* INPLACE_ARRAY1, int DIM1) {(float* data_beg, const size_t n)}

--- a/src/ext/swig/metrics.i
+++ b/src/ext/swig/metrics.i
@@ -140,6 +140,7 @@ METRICS_EXCEPTION_WRAPPER(WRAP_EXCEPTION)
     WRAPPER(index_metric)
     WRAPPER(q_collapsed_metric)
     WRAPPER(q_by_lane_metric)
+    WRAPPER(summary_run_metric)
 %enddef
 
 

--- a/src/interop/CMakeLists.txt
+++ b/src/interop/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SRCS
         model/metrics/q_metric.cpp
         model/metrics/index_metric.cpp
         model/metrics/q_collapsed_metric.cpp
+        model/metrics/summary_run_metric.cpp
         model/summary/run_summary.cpp
         logic/plot/plot_by_cycle.cpp
         logic/plot/plot_by_lane.cpp
@@ -35,7 +36,8 @@ set(SRCS
         logic/plot/plot_metric_list.cpp
         logic/metric/index_metric.cpp
         model/metrics/extended_tile_metric.cpp
-        logic/metric/extended_tile_metric.cpp)
+        logic/metric/extended_tile_metric.cpp
+        )
 
 set(HEADERS
         ../../interop/io/paths.h
@@ -59,6 +61,7 @@ set(HEADERS
         ../../interop/model/run/read_info.h
         ../../interop/model/metrics/tile_metric.h
         ../../interop/model/metrics/corrected_intensity_metric.h
+        ../../interop/model/metrics/summary_run_metric.h
         ../../interop/io/layout/base_metric.h
         ../../interop/model/metric_base/metric_set.h
         ../../interop/model/metric_base/base_metric.h

--- a/src/interop/logic/summary/run_summary.cpp
+++ b/src/interop/logic/summary/run_summary.cpp
@@ -14,6 +14,7 @@
 #include "interop/logic/metric/q_metric.h"
 #include "interop/logic/summary/phasing_summary.h"
 #include "interop/logic/metric/dynamic_phasing_metric.h"
+#include "interop/model/metrics/summary_run_metric.h"
 
 
 namespace illumina { namespace interop { namespace logic { namespace summary
@@ -98,6 +99,13 @@ namespace illumina { namespace interop { namespace logic { namespace summary
             return lhs.lane() < rhs.lane();
         }
     }
+
+    void set_run_summary_metric(const model::metrics::summary_run_metric &summary_run, model::summary::metric_summary& summary)
+    {
+        summary.percent_occupied(static_cast<float>(summary_run.percent_occupied()));
+        summary.percent_occupancy_proxy(static_cast<float>(summary_run.percent_occupancy_proxy()));
+    }
+
 
     /** Summarize a collection run metrics
      *
@@ -198,6 +206,16 @@ namespace illumina { namespace interop { namespace logic { namespace summary
                                   naming_method,
                                   skip_median);
 
+        if(!metrics.get<summary_run_metric>().empty())
+        {
+            const summary_run_metric &summary_run = metrics.get<summary_run_metric>().at(0);
+            set_run_summary_metric(summary_run, summary.nonindex_summary());
+            set_run_summary_metric(summary_run, summary.total_summary());
+            for (size_t read = 0; read < summary.size(); ++read)
+            {
+                set_run_summary_metric(summary_run, summary[read].summary());
+            }
+        }
         if(trim)
         {
             // Remove the empty lane summary entries

--- a/src/interop/model/metrics/summary_run_metric.cpp
+++ b/src/interop/model/metrics/summary_run_metric.cpp
@@ -1,0 +1,192 @@
+/** Register format layouts for summary run metrics
+ *
+ * Each version of the summary run metrics file has a layout defined below.
+ *
+ *  @file
+ *  @date 7/06/2020
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+
+#include <vector>
+#include <algorithm>
+#include "interop/model/metrics/summary_run_metric.h"
+#include "interop/io/format/metric_format_factory.h"
+#include "interop/io/format/text_format_factory.h"
+#include "interop/io/format/text_format.h"
+#include "interop/io/format/default_layout.h"
+#include "interop/io/format/metric_format.h"
+
+using namespace illumina::interop::model::metrics;
+
+namespace illumina { namespace interop { namespace io
+{
+#pragma pack(1)
+
+    /** Summary Run Metric Record Layout Version 1
+     *
+     * This class provides an interface to reading the summary run metric file:
+     *  - InterOp/SummaryRun.bin
+     *  - InterOp/SummaryRunOut.bin
+     *
+     * The class takes two template arguments:
+     *
+     *      1. Metric Type: summary_run_metric
+     *      2. Version: 1
+     */
+    template<>
+    struct generic_layout<summary_run_metric, 1> : public default_layout<1>
+    {
+        /** @page summary_run_v1 SummaryRun Version 1
+         *
+         * This class provides an interface to reading the SummaryRun metric file:
+         *  - InterOp/SummaryRun.bin
+         *  - InterOp/SummaryRunOut.bin
+         *
+         *  The file format for SummaryRun metrics is as follows:
+         *
+         *  @b Header
+         *
+         *  illumina::interop::io::metric_format_stream (Class that parses this information)
+         *
+         *          byte 0: version number (1)
+         *
+         *  @b n-Records
+         *
+         *  illumina::interop::io::generic_layout<summary_run_metric, 1> (Class that parses this information)
+         *          2 byte: dummy (int16)
+         *          4 byte: occupancy proxy cluster count (float)
+         *          4 byte: raw cluster count (float)
+         *          4 byte: occupancy cluster count (float)
+         *          4 byte: PF cluster count (float)
+         */
+
+        /** Metric ID type */
+        typedef layout::base_run_metric metric_id_t;
+
+        /** Define a record size type */
+        typedef ::uint32_t record_size_t;
+
+        /**Count type */
+        typedef summary_run_metric::count_t count_t;
+
+        /** Map reading/writing to stream
+         *
+         * Reading and writing are symmetric operations, map it once
+         *
+         * @param stream input/output stream
+         * @param metric source/destination metric
+         * @param header metric header layout
+         * @return number of bytes read or total number of bytes written
+         */
+        template<class Stream, class Metric, class Header>
+        static std::streamsize map_stream(Stream &stream, Metric &metric, Header &/*header*/, const bool)
+        {
+            std::streamsize count = 0;
+            count += stream_map< count_t >(stream, metric.m_occupancy_proxy_cluster_count);
+            count += stream_map< count_t >(stream, metric.m_raw_cluster_count);
+            count += stream_map< count_t >(stream, metric.m_occupied_cluster_count);
+            count += stream_map< count_t >(stream, metric.m_pf_cluster_count);
+            return count;
+        }
+
+        /** Compute the layout size
+         *
+         * @return size of the record
+         */
+        static record_size_t compute_size(const summary_run_metric::header_type &/*header*/)
+        {
+            const size_t metric_id_byte_count = sizeof(metric_id_t);
+            return static_cast<record_size_t>(
+                    metric_id_byte_count +
+                    sizeof(count_t) +
+                    sizeof(count_t) +
+                    sizeof(count_t) +
+                    sizeof(count_t)
+            );
+        }
+        /** Compute header size
+         *
+         * @return header size
+         */
+        static record_size_t compute_header_size(const summary_run_metric::header_type&)
+        {
+            return static_cast<record_size_t>(sizeof(record_size_t) + sizeof(version_t));
+        }
+    };
+
+#pragma pack() // DO NOT MOVE
+    /** Static Run Metric CSV text format
+     *
+     * This class provide an interface for writing the summary run metrics to a CSV file:
+     *
+     *  - SummaryRun.csv
+     */
+    template<>
+    struct text_layout< summary_run_metric, 1 >
+    {
+        /** Define a header type */
+        typedef summary_run_metric::header_type header_type;
+        /** Write header to the output stream
+         *
+         * @param out output stream
+         * @param header metric set header
+         * @param sep column separator
+         * @param eol row separator
+         * @return number of column headers
+         */
+        static size_t write_header(std::ostream& out,
+                                   const header_type& /*header*/,
+                                   const std::vector<std::string>&,
+                                   const char sep,
+                                   const char eol)
+        {
+            const char* column_headers[] =
+            {
+                "Raw Cluster Count", "Occupied Cluster Count", "PF Cluster Count", "Occupancy Proxy Cluster Count"
+            };
+            std::vector<std::string> headers;
+            headers.reserve(util::length_of(column_headers));
+            for(size_t i=0;i<util::length_of(column_headers);++i)
+                headers.push_back(column_headers[i]);
+            
+            out << "# Column Count: " << util::length_of(headers) << eol;
+            out << headers[0];
+            for(size_t i=1;i<util::length_of(headers);++i)
+                out << sep << headers[i];
+            out << eol;
+            return util::length_of(headers);
+        }
+        /** Write a summary run metric to the output stream
+         *
+         * @param out output stream
+         * @param metric summary run metric
+         * @param header metric set header
+         * @param sep column separator
+         * @param eol row separator
+         * @return number of columns written
+         */
+        static size_t write_metric(std::ostream& out,
+                                   const summary_run_metric& metric,
+                                   const header_type& /*header*/,
+                                   const char sep,
+                                   const char eol,
+                                   const char)
+        {
+            out << metric.raw_cluster_count() << sep
+                << metric.occupied_cluster_count() << sep
+                << metric.pf_cluster_count() << sep
+                << metric.occupancy_proxy_cluster_count();
+            out << eol;
+            return 0;
+        }
+    };
+
+}}}
+
+INTEROP_FORCE_LINK_DEF(summary_run_metric)
+
+INTEROP_REGISTER_METRIC_GENERIC_LAYOUT(summary_run_metric, 1)
+
+// Text formats
+INTEROP_REGISTER_METRIC_TEXT_LAYOUT(summary_run_metric, 1)

--- a/src/interop/model/run_metrics.cpp
+++ b/src/interop/model/run_metrics.cpp
@@ -193,6 +193,10 @@ namespace illumina { namespace interop { namespace model { namespace metrics
             if (!metrics.empty() && m_naming_method == constants::UnknownTileNamingMethod)
                 m_naming_method = logic::metric::tile_naming_method_from_metric(metrics);
         }
+        template<class MetricSet>
+        void determine(const MetricSet &, const constants::base_run_t *)
+        {
+        }
 
     private:
         constants::tile_naming_method m_naming_method;
@@ -229,7 +233,7 @@ namespace illumina { namespace interop { namespace model { namespace metrics
     {
     public:
         read_metric_set_from_binary_buffer(const constants::metric_group group,
-                                           uint8_t* buffer,
+                                           ::uint8_t* buffer,
                                            const size_t buffer_size) :
                 m_group(group),
                 m_buffer(buffer),
@@ -747,7 +751,7 @@ namespace illumina { namespace interop { namespace model { namespace metrics
      * @param buffer_size size of binary buffer
      */
     void run_metrics::read_metrics_from_buffer(const constants::metric_group group,
-                                               uint8_t* buffer,
+                                               ::uint8_t* buffer,
                                                const size_t buffer_size) INTEROP_THROW_SPEC((
     io::file_not_found_exception,
     io::bad_format_exception,
@@ -763,7 +767,7 @@ namespace illumina { namespace interop { namespace model { namespace metrics
      * @param buffer_size size of binary buffer
      */
     void run_metrics::write_metrics_to_buffer(const constants::metric_group group,
-                                              uint8_t* buffer,
+                                              ::uint8_t* buffer,
                                               const size_t buffer_size)const INTEROP_THROW_SPEC((
     io::invalid_argument,
     io::bad_format_exception,

--- a/src/interop/model/run_metrics_helper.cpp
+++ b/src/interop/model/run_metrics_helper.cpp
@@ -32,6 +32,8 @@ namespace illumina { namespace interop { namespace model { namespace metrics
          }
 
          template<class MetricSet>
+         void populate_id(const MetricSet &, const constants::base_run_t *) const {}
+         template<class MetricSet>
          void populate_id(const MetricSet &, const constants::base_lane_t *) const {}
 
          run_metrics::tile_metric_map_t &m_map;

--- a/src/tests/interop/CMakeLists.txt
+++ b/src/tests/interop/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SRCS
         metrics/tile_metrics_test.cpp
         metrics/q_by_lane_metric_test.cpp
         metrics/q_collapsed_metrics_test.cpp
+        metrics/summary_run_metrics_test.cpp
         metrics/base_metric_tests.cpp
         metrics/run_metric_test.cpp
         metrics/metric_streams_test.cpp
@@ -56,6 +57,7 @@ set(HEADERS
         metrics/inc/tile_metrics_test.h
         metrics/inc/q_collapsed_metrics_test.h
         metrics/inc/extended_tile_metrics_test.h
+        metrics/inc/summary_run_metrics_test.h
         inc/failure_listener.h
         inc/persistent_parameter_generator.h
         inc/generic_fixture.h

--- a/src/tests/interop/metrics/extended_tile_metrics_test.cpp
+++ b/src/tests/interop/metrics/extended_tile_metrics_test.cpp
@@ -25,12 +25,10 @@ typedef metric_set< extended_tile_metric > extended_tile_metric_set;
 struct extended_tile_metrics_tests : public generic_test_fixture< extended_tile_metric_set > {};
 
 extended_tile_metrics_tests::generator_type extended_tile_unit_test_generators[] = {
-        // IUO
         wrap(new hardcoded_metric_generator< extended_tile_metric_v1 >),
         wrap(new write_read_metric_generator< extended_tile_metric_v1 >),
         wrap(new by_cycle_metric_generator< extended_tile_metric_v1 >),
         wrap(new clear_metric_generator< extended_tile_metric_v1 >),
-        // End IUO
         wrap(new hardcoded_metric_generator< extended_tile_metric_v2 >),
         wrap(new by_cycle_metric_generator< extended_tile_metric_v2 >),
         wrap(new write_read_metric_generator< extended_tile_metric_v2 >),

--- a/src/tests/interop/metrics/inc/metric_format_fixtures.h
+++ b/src/tests/interop/metrics/inc/metric_format_fixtures.h
@@ -19,6 +19,7 @@
 #include "src/tests/interop/metrics/inc/q_metrics_test.h"
 #include "src/tests/interop/metrics/inc/tile_metrics_test.h"
 #include "src/tests/interop/metrics/inc/extended_tile_metrics_test.h"
+#include "src/tests/interop/metrics/inc/summary_run_metrics_test.h"
 
 namespace illumina{ namespace interop { namespace unittest
 {
@@ -57,7 +58,8 @@ namespace illumina{ namespace interop { namespace unittest
                     q_metric_v6_unbinned,
                     q_metric_v7,
                     tile_metric_v2,
-                    tile_metric_v3
+                    tile_metric_v3,
+                    summary_run_v1
             > PublicFormats;
 
 

--- a/src/tests/interop/metrics/inc/metric_generator.h
+++ b/src/tests/interop/metrics/inc/metric_generator.h
@@ -162,6 +162,7 @@ namespace illumina{ namespace interop { namespace unittest
         {
             typedef typename metric_set_t::metric_type metric_t;
             typedef typename metric_t::uint_t uint_t;
+            typedef typename metric_set_t::metric_comparison_t metric_comparison_t;
 
             std::string expected_data;
             {
@@ -181,10 +182,10 @@ namespace illumina{ namespace interop { namespace unittest
                 metric_t tmp = expected[0];
                 const size_t n = expected.size();
                 for(size_t i=0;i<n;++i)
-                    max_tile_id = std::max(expected[i].tile(), max_tile_id);
+                    max_tile_id = std::max(metric_comparison_t::to_tile(expected[i]), max_tile_id);
                 for(uint_t i=0;i<n;++i)
                 {
-                    tmp.set_base(tmp.lane(), max_tile_id+1+i);
+                    tmp.set_base(metric_comparison_t::to_lane(tmp), max_tile_id+1+i);
                     expected.insert(tmp);
                     expected_metric_set2.insert(tmp);
                 }

--- a/src/tests/interop/metrics/inc/summary_run_metrics_test.h
+++ b/src/tests/interop/metrics/inc/summary_run_metrics_test.h
@@ -1,0 +1,52 @@
+/** Unit tests for the summary run metrics
+ *
+ *  @file
+ *  @date 7/8/16
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+#pragma once
+#include <gtest/gtest.h>
+#include "metric_test.h"
+#include "interop/model/metrics/summary_run_metric.h"
+#include "interop/model/summary/run_summary.h"
+
+namespace illumina{ namespace interop { namespace unittest 
+{
+
+    /** This test writes three records of an InterOp files, then reads them back in and compares
+     * each value to ensure they did not change.
+     * 
+     * @see model::metrics::summary_run_metric
+     * @note Version 1
+     */
+    struct summary_run_v1 : metric_test<model::metrics::summary_run_metric, 1>
+    {
+        /** Create the expected metric set
+         *
+         * @param metrics destination metric set
+         */
+        static void create_expected(metric_set_t &metrics, const model::run::info& =model::run::info())
+        {
+            metrics = metric_set_t(header_t(), VERSION);
+            metrics.insert(metric_t(1.0f, 2.0f, 3.0f, 4.0f));// Only supports single metric!
+        }
+        /** Get the expected binary data
+         *
+         * @param buffer binary data string
+         */
+        template<class Collection>
+        static void create_binary_data(Collection &buffer)
+        {
+            const int tmp[] =
+            {
+                    1
+                    ,34,0,0,0,0,0,0,0,0,0,0,0,-16,63,0,0,0,0,0,0
+                    ,0,64,0,0,0,0,0,0,8,64,0,0,0,0,0,0,16,64
+            };
+            buffer.assign(tmp, tmp+util::length_of(tmp));
+        }
+    };
+
+}}}
+

--- a/src/tests/interop/metrics/metric_streams_test.cpp
+++ b/src/tests/interop/metrics/metric_streams_test.cpp
@@ -15,6 +15,7 @@
 #include "interop/io/metric_stream.h"
 #include "interop/io/metric_file_stream.h"
 #include "src/tests/interop/metrics/inc/metric_format_fixtures.h"
+#include "src/tests/interop/run/info_test.h"
 
 using namespace illumina::interop;
 using namespace illumina::interop::unittest;

--- a/src/tests/interop/metrics/run_metric_test.cpp
+++ b/src/tests/interop/metrics/run_metric_test.cpp
@@ -99,6 +99,9 @@ TEST(run_metric_test, summary_subset_of_imaging)
     ASSERT_EQ(load_imaging.size(), load_summary.size());
     for(size_t i=0;i<load_summary.size();++i)
     {
+        // This metric is not avaiable in the imaging table
+        if( static_cast<constants::metric_group>(i) == static_cast<constants::metric_group>(model::metrics::summary_run_metric::TYPE))
+            continue;
         EXPECT_TRUE(load_summary[i] == 0 || load_summary[i] == load_imaging[i])
                             << constants::to_string(static_cast<constants::metric_group>(i));
     }
@@ -107,15 +110,18 @@ TEST(run_metric_test, summary_subset_of_imaging)
 TYPED_TEST_P(run_metric_test, append_tiles)
 {
     typedef typename TestFixture::metric_set_t metric_set_t;
+    typedef typename metric_set_t::base_t base_t;
+    typedef typename metric_set_t::metric_comparison_t metric_comparison_t;
+
+    if(base_t::value() == constants::BaseRunType) return;
     metric_set_t& metric_set = TestFixture::expected. template  get<metric_set_t>();
 
     const model::metric_base::base_metric tile_id;
-    //tile_id.
-    //= metric_set[0];
     size_t count_expected = 0;
     for(size_t i=0;i<metric_set.size();++i)
     {
-        if(tile_id.lane() == metric_set[i].lane() && tile_id.tile() == metric_set[i].tile())
+        if(metric_comparison_t::to_lane(tile_id) == metric_comparison_t::to_lane(metric_set[i]) &&
+                metric_comparison_t::to_tile(tile_id) == metric_comparison_t::to_tile(metric_set[i]))
             count_expected++;
     }
     model::metrics::run_metrics subset;

--- a/src/tests/interop/metrics/summary_run_metrics_test.cpp
+++ b/src/tests/interop/metrics/summary_run_metrics_test.cpp
@@ -1,0 +1,74 @@
+/** Unit tests for the summary run metrics
+ *
+ *
+ *  @file
+ *  @date 6/23/2016
+ *  @version 1.0
+ *  @copyright GNU Public License.
+ */
+
+#include <limits>
+#include <gtest/gtest.h>
+#include "interop/model/run_metrics.h"
+#include "src/tests/interop/metrics/inc/summary_run_metrics_test.h"
+#include "src/tests/interop/inc/generic_fixture.h"
+#include "src/tests/interop/inc/proxy_parameter_generator.h"
+#include "src/tests/interop/metrics/inc/metric_generator.h"
+using namespace illumina::interop::model::metrics;
+using namespace illumina::interop::model::metric_base;
+using namespace illumina::interop::io;
+using namespace illumina::interop::unittest;
+using namespace illumina::interop;
+
+
+typedef metric_set< summary_run_metric > summary_run_metric_set;
+/** Setup for tests that compare two metric sets */
+struct summary_run_metrics_tests : public generic_test_fixture< summary_run_metric_set > {};
+
+/** This does not change per cycle */
+by_cycle_metric_generator< summary_run_v1 > summary_run_dummy_v1;
+
+
+summary_run_metrics_tests::generator_type summary_run_unit_test_generators[] = {
+        wrap(new hardcoded_metric_generator< summary_run_v1 >),
+        wrap(new write_read_metric_generator< summary_run_v1 >),
+        wrap(new clear_metric_generator< summary_run_v1 >)
+};
+
+// Setup unit tests for summary_run_metrics_tests
+INSTANTIATE_TEST_CASE_P(summary_run_metric_unit_test,
+                        summary_run_metrics_tests,
+                        ::testing::ValuesIn(summary_run_unit_test_generators));
+
+/**
+ * @class illumina::interop::model::metrics::summary_run_metric
+ * @test Confirm version 1 of the metric can be written to and read from a stream
+ * @test Confirm version 1 of the metric matches known binary file
+ */
+TEST_P(summary_run_metrics_tests, test_read_write)
+{
+    typedef summary_run_metric_set::const_iterator const_iterator;
+    if(skip_test) return;
+    ASSERT_TRUE(fixture_test_result);
+    EXPECT_EQ(actual.version(), expected.version());
+    EXPECT_EQ(actual.size(), expected.size());
+    const float eps = 1e-7f;
+    for (const_iterator it_expected = expected.begin(), it_actual = actual.begin();
+         it_expected != expected.end() && it_actual != actual.end();
+         it_expected++, it_actual++)
+    {
+        EXPECT_NEAR(it_expected->raw_cluster_count(), it_actual->raw_cluster_count(), eps);
+        EXPECT_NEAR(it_expected->occupied_cluster_count(), it_actual->occupied_cluster_count(), eps);
+        EXPECT_NEAR(it_expected->pf_cluster_count(), it_actual->pf_cluster_count(), eps);
+        EXPECT_NEAR(it_expected->occupancy_proxy_cluster_count(), it_actual->occupancy_proxy_cluster_count(), eps);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Setup regression test
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+regression_test_metric_generator<summary_run_metric_set> summary_run_regression_gen;
+INSTANTIATE_TEST_CASE_P(summary_run_metric_regression_test,
+                        summary_run_metrics_tests,
+                        ProxyValuesIn(summary_run_regression_gen, regression_test_data::instance().files()));
+

--- a/src/tests/python/CoreTests.py
+++ b/src/tests/python/CoreTests.py
@@ -196,7 +196,27 @@ class CoreTests(unittest.TestCase):
             py_interop_comm.write_interop_to_buffer(run.extraction_metric_set(), buf)
             self.fail("invalid_argument should have been thrown")
         except py_interop_comm.invalid_argument as ex:
-            self.assertEqual(str(ex).split('\n')[0], "Buffer size too small")
+            self.assertEqual(str(ex).split('\n')[0], "Buffer size too small: 3 < 116")
+
+    def test_invalid_argument_run_metrics_read(self):
+        """
+        Test that exceptions can be caught and they have the expected message
+        """
+
+        tmp = numpy.asarray(
+            [2,38
+                ,7,0,90,4,1,0,-12,-56,15,64,-98,35,12,64,0,0,0,0,0,0,0,0,46,1,17,1,0,0,0,0,96,-41,-104,36,122,-86,-46,-120
+                ,7,0,-66,4,1,0,96,-43,14,64,-63,49,13,64,0,0,0,0,0,0,0,0,56,1,17,1,0,0,0,0,112,125,77,38,122,-86,-46,-120
+                ,7,0,66,8,1,0,74,-68,6,64,-118,-7,8,64,0,0,0,0,0,0,0,0,93,1,46,1,0,0,0,0,-47,-104,2,40,122,-86,-46,-120],
+            dtype=numpy.uint8)
+        run = py_interop_run_metrics.run_metrics()
+        run.read_metrics_from_buffer(py_interop_run.Extraction, tmp)
+        try:
+            buf = numpy.zeros(3, dtype=numpy.uint8)
+            py_interop_comm.write_interop_to_buffer(run.extraction_metric_set(), buf)
+            self.fail("invalid_argument should have been thrown")
+        except py_interop_comm.invalid_argument as ex:
+            self.assertEqual(str(ex).split('\n')[0], "Buffer size too small: 3 < 116")
 
     def test_invalid_filter_option(self):
         """
@@ -236,7 +256,7 @@ class CoreTests(unittest.TestCase):
             run_metrics.read_metrics("", 3, valid_to_load, 1)
             self.fail("invalid_parameter should have been thrown")
         except py_interop_run_metrics.invalid_parameter as ex:
-            self.assertEqual(str(ex).split('\n')[0], "Boolean array valid_to_load does not match expected number of metrics: 2 != 12")
+            self.assertEqual(str(ex).split('\n')[0], "Boolean array valid_to_load does not match expected number of metrics: 2 != 13")
 
     def test_invalid_metric_type(self):
         """
@@ -401,6 +421,14 @@ class CoreTests(unittest.TestCase):
         """
 
         self.assertEqual(py_interop_run.to_string_metric_group(py_interop_run.Error), "Error")
+
+    def test_summary_run_metric_set_method(self):
+        """
+        Test if the enum parsing is properly wrapped
+        """
+
+        run = py_interop_run_metrics.run_metrics()
+        summary_run_metric_set = run.summary_run_metric_set()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The NextSeq 1k/2k supports a new metric called `% Loading concentration`. Within the InterOp library his is known as the occupancy proxy. 

On previous systems, we could judge input concentration from occupancy. Changes in NextSeq 1k/2k necessitate a new metric.

```
from interop import py_interop_run_metrics, py_interop_summary
run_metrics = py_interop_run_metrics.run_metrics()
run_metrics.read(run_folder)
run_summary = py_interop_summary.run_summary()
py_interop_summary.summarize_run_metrics(run_metrics, run_summary,)
print(run_summary.total_summary().percent_occupancy_proxy())
```