### PR TITLE
Add test for .NET standard artifacts

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -50,6 +50,9 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: docker run --rm -v ${{github.workspace}}/:/io ezralanglois/interop bash -c "cmake /io -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=/io/dist -DENABLE_SWIG=OFF -DENABLE_PORTABLE=ON && cmake --build build && cmake --build build --target check && cmake --build build --target bundle"
 
+      - name: Test Artifacts
+        run: ls dist/*
+
       - uses: actions/upload-artifact@v3
         if: matrix.buildtype == 'Release'
         with:

--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -28,11 +28,11 @@ jobs:
 
       - name: Configure Windows
         if: matrix.os == 'windows-latest'
-        run: cmake ${{github.workspace}} -Ax64 -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=OFF -DENABLE_PORTABLE=ON
+        run: cmake ${{github.workspace}} -Ax64 -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=OFF -DENABLE_PORTABLE=ON -DDISABLE_PACKAGE_SUBDIR=ON
 
       - name: Configure OSX
         if: matrix.os == 'macOS-latest'
-        run: cmake ${{github.workspace}} -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=OFF -DENABLE_PORTABLE=ON
+        run: cmake ${{github.workspace}} -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=OFF -DENABLE_PORTABLE=ON -DDISABLE_PACKAGE_SUBDIR=ON
 
       - name: Build OSX and Windows
         if: matrix.os != 'ubuntu-latest'
@@ -48,7 +48,7 @@ jobs:
 
       - name: Linux Build, Test and Package in Docker
         if: matrix.os == 'ubuntu-latest'
-        run: docker run --rm -v ${{github.workspace}}/:/io ezralanglois/interop bash -c "cmake /io -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=/io/dist -DENABLE_SWIG=OFF -DENABLE_PORTABLE=ON && cmake --build build && cmake --build build --target check && cmake --build build --target bundle"
+        run: docker run --rm -v ${{github.workspace}}/:/io ezralanglois/interop bash -c "cmake /io -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=/io/dist -DENABLE_SWIG=OFF -DENABLE_PORTABLE=ON -DDISABLE_PACKAGE_SUBDIR=ON && cmake --build build && cmake --build build --target check && cmake --build build --target bundle"
 
       - name: Test Artifacts
         run: ls dist/*
@@ -73,3 +73,4 @@ jobs:
         uses: fnkr/github-action-ghr@v1
         env:
           GHR_PATH: dist/
+          GITHUB_TOKEN: ${{ secrets.RELEASES_TOKEN }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -51,6 +51,9 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: docker run --rm -v ${{github.workspace}}/:/io ezralanglois/interop bash -c "cmake /io -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=/io/dist -DENABLE_SWIG=ON -DENABLE_PORTABLE=ON -DENABLE_EXAMPLES=OFF -DENABLE_CSHARP=ON -DENABLE_PYTHON=OFF && cmake --build build && cmake --build build --target check && cmake --build build --target nupack"
 
+      - name: Test Artifacts
+        run: ls dist/*
+
       - uses: actions/upload-artifact@v3
         if: matrix.buildtype == 'Release'
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: matrix.buildtype == 'Release'
         with:
-          path: dist/*.*
+          path: dist/illumina*.*
 
   publish:
     needs: [build]
@@ -74,3 +74,4 @@ jobs:
         uses: fnkr/github-action-ghr@v1
         env:
           GHR_PATH: dist/
+          GITHUB_TOKEN: ${{ secrets.RELEASES_TOKEN }}

--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -5,6 +5,7 @@
 
 Date       | Description
 ---------- | -----------
+2022-06-25 | Add test for .NET standard artifacts
 2022-06-16 | Deploy .NET Standard Nuget package on public repo using Github Actions
 2022-06-16 | Deploy C++ applications on public repo using Github Actions
 2022-06-15 | IPA-10585: Add github action support for deploying docs


### PR DESCRIPTION
This is a set of bug fixes due to the fact that both apps and dotnet nuget packages failed to deploy

- Fixed apps packaged in a subdirectory
- Fixed missing github releases missing token