### PR TITLE
Fix InterOp Python Wheels do not run on Mac OS X High Sierra 10.13

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,5 +1,8 @@
 name: Python Wheels
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: 10.9
+
 on:
   push:
     branches: [ "master" ]

--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -1,6 +1,12 @@
 # Changes                                               {#changes}
 
 
+## v1.1.26
+
+Date       | Description
+---------- | -----------
+2022-07-18 | Fix InterOp Python Wheels do not run on Mac OS X High Sierra 10.13 since v1.1.24
+
 ## v1.1.25
 
 Date       | Description


### PR DESCRIPTION
Happened with switch to github actions in v1.1.24

Resolves #293