### PR TITLE
Fix issue where wheels cannot be updated

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -98,6 +98,7 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: ./dist
+          skip_existing: true
 
 
 

--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -1,6 +1,13 @@
 # Changes                                               {#changes}
 
 
+## v1.1.27
+
+Date       | Description
+---------- | -----------
+2022-08-23 | Fix issue where wheels cannot be updated
+
+
 ## v1.1.26
 
 Date       | Description


### PR DESCRIPTION
You cannot reupload an artifact to PyPI (even if you delete it in PyPI). 

So if your build fails during publish, there is no easy way to add more artifacts. This fixes that issue