### PR TITLE
Issue-322: Fix segfault with dumptext when writing out adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ Quick Start
 [![Coverity_status][covstatus]][covhome]
 
 The Illumina InterOp libraries are a set of common routines used for reading InterOp metric files produced by
-Illumina sequencers including **NextSeq 1k/2k**. These libraries are backwards compatible and capable of supporting prior releases of the software,
+Illumina sequencers including **NextSeq 1k/2k** and NovaSeqX. These libraries are backwards compatible and capable of supporting prior releases of the software,
 with one exception: GA systems have been excluded.
 
 ***
 > We now support an interface to Python 2.7 (UCS-4) and 3.6-3.10
-> Note that 3.10 is CentOS 7 or later while ealier versions support Centos 5 or later
+> Note that 3.10 is CentOS 7 or later while earlier versions support Centos 5 or later
+> Note: dumptext has been deprecated in favor of imaging_table and will be removed in the next version
 ***
 
 The InterOp files supported by this library include:

--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -1,5 +1,11 @@
 # Changes {#changes}
 
+## v1.2.4
+
+| Date       | Description                                                                            |
+|------------|----------------------------------------------------------------------------------------|
+| 2023-05-12 | Issue-322: Fix segfault with dumptext when writing out adapter, but no adapter present |
+
 ## v1.2.3
 
 | Date       | Description                                                             |

--- a/src/interop/model/metrics/error_metric.cpp
+++ b/src/interop/model/metrics/error_metric.cpp
@@ -608,8 +608,11 @@ namespace illumina{ namespace interop{ namespace io
                                    const char)
         {
             out << metric.lane() << sep << metric.tile() << sep << metric.cycle() << sep;
-            out << metric.error_rate() << sep << metric.phix_adapter_rates()[0];
-            for(size_t i=1;i<static_cast<size_t>(header.number_adapters());++i)
+            if(metric.phix_adapter_rates().size() > 0)
+                out << metric.error_rate() << sep << metric.phix_adapter_rates()[0];
+            else
+                out << metric.error_rate();
+            for(size_t i=1;i<static_cast<size_t>(metric.phix_adapter_rates().size());++i)
                 out << sep << metric.phix_adapter_rates()[i];
             out << eol;
             return 0;

--- a/src/interop/model/metrics/error_metric.cpp
+++ b/src/interop/model/metrics/error_metric.cpp
@@ -602,7 +602,7 @@ namespace illumina{ namespace interop{ namespace io
          */
         static size_t write_metric(std::ostream& out,
                                    const error_metric& metric,
-                                   const header_type& header,
+                                   const header_type& /*header*/,
                                    const char sep,
                                    const char eol,
                                    const char)


### PR DESCRIPTION
Happens when no adapter is present

Resolves #322