### PR TITLE
Issue-348: Interop is not compatible with Numpy 2.0.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Configure OSX
         if: matrix.os == 'macOS-13'
-        run: cmake ${{github.workspace}} -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=ON -DENABLE_PORTABLE=ON -DENABLE_EXAMPLES=OFF -DENABLE_CSHARP=ON -DENABLE_PYTHON=OFF -DCSHARP_TEST_FRAMEWORK=netcoreapp6 -DSWIG_EXECUTABLE=$(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/bin/swig) -DSWIG_DIR=$(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/bin/swig)/../../share/swig/4.0.2/
+        run: cmake ${{github.workspace}} -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=ON -DENABLE_PORTABLE=ON -DENABLE_EXAMPLES=OFF -DENABLE_CSHARP=ON -DENABLE_PYTHON=OFF -DCSHARP_TEST_FRAMEWORK=netcoreapp6 -DSWIG_EXECUTABLE=$(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/bin/swig) -DSWIG_DIR=$( cd "$(pwd)/usr/lib/python3.*/site-packages/swig/data/share/swig/4.0.2" ; pwd -P )
 
       - name: Build OSX and Windows
         if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-13]
         buildtype: ["Debug", "Release"]
 
     steps:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Configure OSX
         if: matrix.os == 'macOS-13'
-        run: cmake ${{github.workspace}} -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=ON -DENABLE_PORTABLE=ON -DENABLE_EXAMPLES=OFF -DENABLE_CSHARP=ON -DENABLE_PYTHON=OFF -DCSHARP_TEST_FRAMEWORK=netcoreapp6 -DSWIG_EXECUTABLE=$(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/bin/swig) -DSWIG_DIR=$(dirname $(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/share/swig/4.0.2/swig.swg))
+        run: cmake ${{github.workspace}} -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=ON -DENABLE_PORTABLE=ON -DENABLE_EXAMPLES=OFF -DENABLE_CSHARP=ON -DENABLE_PYTHON=OFF -DCSHARP_TEST_FRAMEWORK=netcoreapp7 -DSWIG_EXECUTABLE=$(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/bin/swig) -DSWIG_DIR=$(dirname $(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/share/swig/4.0.2/swig.swg))
 
       - name: Build OSX and Windows
         if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Configure OSX
         if: matrix.os == 'macOS-13'
-        run: cmake ${{github.workspace}} -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=ON -DENABLE_PORTABLE=ON -DENABLE_EXAMPLES=OFF -DENABLE_CSHARP=ON -DENABLE_PYTHON=OFF -DCSHARP_TEST_FRAMEWORK=netcoreapp6 -DSWIG_EXECUTABLE=$(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/bin/swig) -DSWIG_DIR=$( cd "$(pwd)/usr/lib/python3.*/site-packages/swig/data/share/swig/4.0.2" ; pwd -P )
+        run: cmake ${{github.workspace}} -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=ON -DENABLE_PORTABLE=ON -DENABLE_EXAMPLES=OFF -DENABLE_CSHARP=ON -DENABLE_PYTHON=OFF -DCSHARP_TEST_FRAMEWORK=netcoreapp6 -DSWIG_EXECUTABLE=$(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/bin/swig) -DSWIG_DIR=$(dirname $(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/share/swig/4.0.2/swig.swg))
 
       - name: Build OSX and Windows
         if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,7 +32,7 @@ jobs:
         run: cmake ${{github.workspace}} -Ax64 -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=ON -DENABLE_PORTABLE=ON -DENABLE_EXAMPLES=OFF -DENABLE_CSHARP=ON -DENABLE_PYTHON=OFF -DCSHARP_TEST_FRAMEWORK=netcoreapp6
 
       - name: Configure OSX
-        if: matrix.os == 'macOS-latest'
+        if: matrix.os == 'macOS-13'
         run: cmake ${{github.workspace}} -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=ON -DENABLE_PORTABLE=ON -DENABLE_EXAMPLES=OFF -DENABLE_CSHARP=ON -DENABLE_PYTHON=OFF -DCSHARP_TEST_FRAMEWORK=netcoreapp6
 
       - name: Build OSX and Windows

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -31,9 +31,13 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: cmake ${{github.workspace}} -Ax64 -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=ON -DENABLE_PORTABLE=ON -DENABLE_EXAMPLES=OFF -DENABLE_CSHARP=ON -DENABLE_PYTHON=OFF -DCSHARP_TEST_FRAMEWORK=netcoreapp6
 
+      - name: Install Swig
+        if: matrix.os == 'macOS-13'
+        run: pip install swig==4.0.2 --prefix="$(pwd)/usr"
+
       - name: Configure OSX
         if: matrix.os == 'macOS-13'
-        run: cmake ${{github.workspace}} -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=ON -DENABLE_PORTABLE=ON -DENABLE_EXAMPLES=OFF -DENABLE_CSHARP=ON -DENABLE_PYTHON=OFF -DCSHARP_TEST_FRAMEWORK=netcoreapp6
+        run: cmake ${{github.workspace}} -B${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DPACKAGE_OUTPUT_FILE_PREFIX=${{github.workspace}}/dist -DENABLE_SWIG=ON -DENABLE_PORTABLE=ON -DENABLE_EXAMPLES=OFF -DENABLE_CSHARP=ON -DENABLE_PYTHON=OFF -DCSHARP_TEST_FRAMEWORK=netcoreapp6 -DSWIG_EXECUTABLE=$(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/bin/swig) -DSWIG_DIR=$(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/bin/swig)/../../share/swig/4.0.2/
 
       - name: Build OSX and Windows
         if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,8 +29,6 @@ jobs:
           python-version: ${{matrix.pyver}}
         id: cpver
 
-      - uses: mmomtchev/setup-swig@v1
-
       - name: Setup Git name
         run: |
           git config user.name "GitHub Actions Bot"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,6 +2,7 @@ name: Python Wheels
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 10.9
+  DOCKER_IMAGE: quay.io/pypa/manylinux2014_x86_64
 
 on:
   push:
@@ -41,19 +42,19 @@ jobs:
 
       - name: Package Python 3.9
         if: matrix.os == 'ubuntu-latest' && matrix.pyver == '3.9'
-        run: docker run --rm -v ${{github.workspace}}/:/io ezralanglois/interop_centos7 sh /io/tools/package.sh /io /io/dist travis OFF Release cp39-cp39
+        run: docker run --rm -v ${{github.workspace}}/:/io $DOCKER_IMAGE sh /io/tools/package.sh /io /io/dist travis OFF Release cp39-cp39
 
       - name: Package Python 3.10
         if: matrix.os == 'ubuntu-latest' && matrix.pyver == '3.10'
-        run: docker run --rm -v ${{github.workspace}}/:/io ezralanglois/interop_centos7 sh /io/tools/package.sh /io /io/dist travis OFF Release cp310-cp310
+        run: docker run --rm -v ${{github.workspace}}/:/io $DOCKER_IMAGE sh /io/tools/package.sh /io /io/dist travis OFF Release cp310-cp310
 
       - name: Package Python 3.11
         if: matrix.os == 'ubuntu-latest' && matrix.pyver == '3.11'
-        run: docker run --rm -v ${{github.workspace}}/:/io ezralanglois/interop_centos7 sh /io/tools/package.sh /io /io/dist travis OFF Release cp311-cp311
+        run: docker run --rm -v ${{github.workspace}}/:/io $DOCKER_IMAGE sh /io/tools/package.sh /io /io/dist travis OFF Release cp311-cp311
 
       - name: Package Python 3.11
         if: matrix.os == 'ubuntu-latest' && matrix.pyver == '3.12'
-        run: docker run --rm -v ${{github.workspace}}/:/io ezralanglois/interop_centos7 sh /io/tools/package.sh /io /io/dist travis OFF Release cp312-cp312
+        run: docker run --rm -v ${{github.workspace}}/:/io $DOCKER_IMAGE sh /io/tools/package.sh /io /io/dist travis OFF Release cp312-cp312
 
       - name: Windows Package Python
         if: matrix.os == 'windows-2019'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2019, macOS-latest]
-        pyver: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        pyver: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macOS-latest]
-        pyver: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, windows-2019, macOS-latest, macOS-13]
+        pyver: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2019, macOS-latest]
-        pyver: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        pyver: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v3
@@ -36,7 +36,7 @@ jobs:
           git --version
 
       - name: Package Python 3.8 and earlier
-        if: matrix.os == 'ubuntu-latest' && matrix.pyver != '3.9' && matrix.pyver != '3.10' && matrix.pyver != '3.11'
+        if: matrix.os == 'ubuntu-latest' && matrix.pyver != '3.9' && matrix.pyver != '3.10' && matrix.pyver != '3.11' && matrix.pyver != '3.12'
         run: docker run --rm -v ${{github.workspace}}/:/io ezralanglois/interop sh /io/tools/package.sh /io /io/dist travis OFF
 
       - name: Package Python 3.9
@@ -50,6 +50,10 @@ jobs:
       - name: Package Python 3.11
         if: matrix.os == 'ubuntu-latest' && matrix.pyver == '3.11'
         run: docker run --rm -v ${{github.workspace}}/:/io ezralanglois/interop_centos7 sh /io/tools/package.sh /io /io/dist travis OFF Release cp311-cp311
+
+      - name: Package Python 3.11
+        if: matrix.os == 'ubuntu-latest' && matrix.pyver == '3.12'
+        run: docker run --rm -v ${{github.workspace}}/:/io ezralanglois/interop_centos7 sh /io/tools/package.sh /io /io/dist travis OFF Release cp312-cp312
 
       - name: Windows Package Python
         if: matrix.os == 'windows-2019'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -63,7 +63,7 @@ jobs:
           tools\package.bat Release "Visual Studio 16 2019" package_wheel "-DENABLE_APPS=OFF -DENABLE_EXAMPLES=OFF -DENABLE_CSHARP=OFF -DPython_EXECUTABLE=${{ steps.cpver.outputs.python-path }}" -DENABLE_PORTABLE=ON -A x64
 
       - name: Mac OSX Package Python
-        if: matrix.os == 'macOS-latest'
+        if: matrix.os == 'macOS-latest' || matrix.os == 'macOS-13'
         run: bash ./tools/package.sh ${{github.workspace}} ${{github.workspace}}/dist travis OFF Release ${{matrix.pyver}}
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macOS-latest, macOS-13]
+        os: [ubuntu-latest, windows-2019, macOS-13]
         pyver: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,6 +29,8 @@ jobs:
           python-version: ${{matrix.pyver}}
         id: cpver
 
+      - uses: mmomtchev/setup-swig@v1
+
       - name: Setup Git name
         run: |
           git config user.name "GitHub Actions Bot"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Illumina sequencers including **NextSeq 1k/2k** and NovaSeqX. These libraries ar
 with one exception: GA systems have been excluded.
 
 ***
-> We now support an interface to 3.7-3.12
+> We now support an interface to 3.8-3.12
 > Note that 3.10-3.12 are CentOS 7 or later while earlier versions support Centos 5 or later
 > Note: dumptext has been deprecated in favor of imaging_table and will be removed in the next version
 ***

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Illumina sequencers including **NextSeq 1k/2k** and NovaSeqX. These libraries ar
 with one exception: GA systems have been excluded.
 
 ***
-> We now support an interface to 3.6-3.11
-> Note that 3.10 and 3.11 are CentOS 7 or later while earlier versions support Centos 5 or later
+> We now support an interface to 3.7-3.12
+> Note that 3.10-3.12 are CentOS 7 or later while earlier versions support Centos 5 or later
 > Note: dumptext has been deprecated in favor of imaging_table and will be removed in the next version
 ***
 

--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -1,5 +1,15 @@
 # Changes {#changes}
 
+## v1.3.2
+
+| Date       | Description                                           |
+|------------|-------------------------------------------------------|
+| 2024-07-12 | Issue-348: Interop is not compatible with Numpy 2.0.0 |
+| 2024-07-12 | Add support for Python 3.12                           |
+| 2024-07-12 | Issue-340: Update simplified interface documentation  |
+| 2024-07-12 | Issue-339: Add link to document metrics on summary    |
+| 2024-07-12 | Issue-338: Improve imaging_table documentation        |
+
 ## v1.3.1
 
 | Date       | Description                                                       |

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -19,7 +19,7 @@ In addition to the binary archive below, there are language specific packages in
  
 Note, we only distribute from GitHub currently, and not PyPi or NuGet.org. These should
 be compatible with most Linux Versions, Mac OSX and Windows. We support
-Python 3.7 to 3.12.
+Python 3.8 to 3.12.
 
 ### Binary Archive (C++, C#, Python, Java)
 
@@ -35,7 +35,7 @@ For Pythons users, a Wheel package is available on Github Releases or PyPI:
 $ pip install interop
 ~~~~~~~~~~~~~
 
-Supported versions for binary distribution: 3.7 to 3.12.
+Supported versions for binary distribution: 3.8 to 3.12.
 
 Test the installation
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -19,7 +19,7 @@ In addition to the binary archive below, there are language specific packages in
  
 Note, we only distribute from GitHub currently, and not PyPi or NuGet.org. These should
 be compatible with most Linux Versions, Mac OSX and Windows. We support
-Python 3.6 to 3.11.
+Python 3.7 to 3.12.
 
 ### Binary Archive (C++, C#, Python, Java)
 
@@ -35,7 +35,7 @@ For Pythons users, a Wheel package is available on Github Releases or PyPI:
 $ pip install interop
 ~~~~~~~~~~~~~
 
-Supported versions for binary distribution: 3.6 to 3.11.
+Supported versions for binary distribution: 3.7 to 3.12.
 
 Test the installation
 

--- a/docs/src/python_binding.md
+++ b/docs/src/python_binding.md
@@ -16,7 +16,7 @@ Older versions (prior to 1.1.3) can be installed using:
     $ pip install -f https://github.com/Illumina/interop/releases/tag/v1.1.2 interop
     $ pip install -f https://github.com/Illumina/interop/releases/latest interop
 
-Note, only Python versions 3.6 to 3.11 are currently 
+Note, only Python versions 3.7 to 3.12 are currently 
 supported as binary builds. Other Python versions must be built 
 from source.
 

--- a/docs/src/python_binding.md
+++ b/docs/src/python_binding.md
@@ -16,7 +16,7 @@ Older versions (prior to 1.1.3) can be installed using:
     $ pip install -f https://github.com/Illumina/interop/releases/tag/v1.1.2 interop
     $ pip install -f https://github.com/Illumina/interop/releases/latest interop
 
-Note, only Python versions 3.7 to 3.12 are currently 
+Note, only Python versions 3.8 to 3.12 are currently 
 supported as binary builds. Other Python versions must be built 
 from source.
 

--- a/docs/src/python_binding.md
+++ b/docs/src/python_binding.md
@@ -32,8 +32,27 @@ Then upgrade numpy and try again.
 
 ## New simplified interface
 
-      from interop import *
+The following will return a structured numpy array
+
+      from interop.core import *
       ar = imaging("path/to/run_folder")
+
+This can be converted to pandas as follows
+
+      import interop.core as ic
+
+      df = pd.DataFrame(ic.imaging(run_folder))
+      change_data_type = {
+      'Lane'             : int,
+      'Tile'             : int,
+      'Tile Number'      : int,
+      'Read'             : int,
+      'Cycle'            : int,
+      'Cycle Within Read': int,
+      'Swath'            : int,
+      'Surface'          : int
+      }
+      df = df.astype(change_data_type)
 
 See new [interop.core](namespacecore.html) wrapper for the simplified interface
 

--- a/src/apps/imaging_table.cpp
+++ b/src/apps/imaging_table.cpp
@@ -36,6 +36,7 @@ int main(int argc, char** argv)
     if (argc == 0)
     {
         std::cerr << "No arguments specified!" << std::endl;
+        std::cout << "Expected: $ imaging_table <run-folder1> <run-folder2> ... <run-folderN>" << std::endl;
         return INVALID_ARGUMENTS;
     }
     const size_t thread_count = 1;
@@ -51,7 +52,11 @@ int main(int argc, char** argv)
         run_metrics run;
         std::cout << "# Run Folder: " << io::basename(argv[i]) << std::endl;
         int ret = read_run_metrics(argv[i], run, valid_to_load, thread_count);
-        if (ret != SUCCESS) return ret;
+        if (ret != SUCCESS)
+        {
+            std::cout << "Expected: $ imaging_table <run-folder1> <run-folder2> ... <run-folderN>" << std::endl;
+            return ret;
+        }
 
 #ifdef INTEROP_TEST_CSHARP_BINDING
         std::vector<model::table::imaging_column> columns;

--- a/src/apps/summary.cpp
+++ b/src/apps/summary.cpp
@@ -10,6 +10,9 @@
  *
  * In this sample, 140131_1287_0851_A01n401drr is a run folder and the summary is written to the standard output.
  *
+ * Note that an exhausive list of metrics can be found here:
+ *   https://support-docs.illumina.com/SW/SAV/Content/SW/SAV/Metrics.htm
+ *
  * The InterOp sub folder may contain any of the following files:
  *
  *  - ErrorMetricsOut.bin

--- a/src/ext/python/core.py
+++ b/src/ext/python/core.py
@@ -25,10 +25,10 @@ array([(0.37, 6.67, 0., 0., 0.)],
 
 >>> from interop import indexing
 >>> indexing(run_metrics_with_indexing)
-array([(1., 1101., 'ATCACGAC-AAGGTTCA', '1', 4570., 900., 507.77777),
-       (1., 1101., 'ATCACGAC-GGGGGGGG', '2', 2343., 900., 260.33334),
-       (1., 1102., 'ATCACGAC-AAGGTTCA', '1', 4570.,   0.,   0.     ),
-       (1., 1102., 'ATCACGAC-GGGGGGGG', '2', 2343.,   0.,   0.     )],
+array([(1., 1101., 'ATCACGAC-AAGGTTCA', '1', 4570., 900., 507.78),
+       (1., 1101., 'ATCACGAC-GGGGGGGG', '2', 2343., 900., 260.33),
+       (1., 1102., 'ATCACGAC-AAGGTTCA', '1', 4570.,   0.,   0.  ),
+       (1., 1102., 'ATCACGAC-GGGGGGGG', '2', 2343.,   0.,   0.  )],
       dtype=[('Lane', '<f4'), ('Tile', '<f4'), ('Barcode', 'O'), ('SampleID', 'O'), ('Cluster Count', '<f4'), ('Cluster Count PF', '<f4'), ('% Demux', '<f4')])
 
 >>> from interop import imaging

--- a/src/ext/python/core.py
+++ b/src/ext/python/core.py
@@ -266,12 +266,11 @@ def summary(run_metrics, level='Total', columns=None, dtype='f4', ignore_missing
 
     If a column values are NaN, or missing, then it will automatically be excluded
     >>> summary(run_metrics_example, 'Total', columns=['% Aligned', 'Error Rate'])
-     array([(0.37,)], dtype=[('Error Rate', '<f4')])
+    array([(0.37,)], dtype=[('Error Rate', '<f4')])
 
     To include missing columns, set `ignore_missing_columns=False`
     >>> summary(run_metrics_example, 'Total', ignore_missing_columns=False, columns=['% Aligned', 'Error Rate'])
-    array([(nan, 0.37)],
-          dtype=[('% Aligned', '<f4'), ('Error Rate', '<f4')])
+    array([(nan, 0.37)], dtype=[('% Aligned', '<f4'), ('Error Rate', '<f4')])
 
     >>> summary(run_metrics_example, 'Total', columns=['Incorrect'])
     Traceback (most recent call last):

--- a/src/ext/python/core.py
+++ b/src/ext/python/core.py
@@ -15,12 +15,12 @@ The core routines include the following:
 
 >>> from interop import index_summary
 >>> index_summary(run_metrics_with_indexing)
-array([(1, 0.4556, 1015.5555, 520.6667, 1536.2222, 1800., 2000.)],
+array([(1, 0.46, 1015.56, 520.67, 1536.22, 1800., 2000.)],
       dtype=[('Lane', '<u2'), ('Mapped Reads Cv', '<f4'), ('Max Mapped Reads', '<f4'), ('Min Mapped Reads', '<f4'), ('Total Fraction Mapped Reads', '<f4'), ('Total Pf Reads', '<f4'), ('Total Reads', '<f4')])
 
 >>> from interop import summary
 >>> summary(run_metrics_example)
-array([(0.36666667, 6.6666665, 0., 0., 0.)],
+array([(0.37, 6.67, 0., 0., 0.)],
       dtype=[('Error Rate', '<f4'), ('First Cycle Intensity', '<f4'), ('Projected Yield G', '<f4'), ('Reads', '<f4'), ('Reads Pf', '<f4')])
 
 >>> from interop import indexing
@@ -71,16 +71,16 @@ def index_summary(run_metrics, level='Lane', columns=None, dtype='f4', **extra):
     >>> ar = index_summary("some/path/run_folder_name") # doctest: +SKIP
 
     >>> index_summary(run_metrics_with_indexing)
-    array([(1, 0.4556, 1015.5555, 520.6667, 1536.2222, 1800., 2000.)],
+    array([(1, 0.46, 1015.56, 520.67, 1536.22, 1800., 2000.)],
           dtype=[('Lane', '<u2'), ('Mapped Reads Cv', '<f4'), ('Max Mapped Reads', '<f4'), ('Min Mapped Reads', '<f4'), ('Total Fraction Mapped Reads', '<f4'), ('Total Pf Reads', '<f4'), ('Total Reads', '<f4')])
 
     >>> index_summary(run_metrics_with_indexing, level='Barcode')
-    array([(1, 18280., 1015.5555, 1., 'ATCACGAC', 'AAGGTTCA', 'TSCAIndexes', '1'),
-           (1,  9372.,  520.6667, 2., 'ATCACGAC', 'GGGGGGGG', 'TSCAIndexes', '2')],
+    array([(1, 18280., 1015.56, 1., 'ATCACGAC', 'AAGGTTCA', 'TSCAIndexes', '1'),
+           (1,  9372.,  520.67, 2., 'ATCACGAC', 'GGGGGGGG', 'TSCAIndexes', '2')],
           dtype=[('Lane', '<u2'), ('Cluster Count', '<f4'), ('Fraction Mapped', '<f4'), ('Id', '<f4'), ('Index1', 'O'), ('Index2', 'O'), ('Project Name', 'O'), ('Sample Id', 'O')])
 
     >>> index_summary(run_metrics_with_indexing, columns=['Total Fraction Mapped Reads'])
-    array([(1, 1536.2222)],
+    array([(1, 1536.22)],
           dtype=[('Lane', '<u2'), ('Total Fraction Mapped Reads', '<f4')])
 
     >>> index_summary(run_metrics_with_indexing, columns=['Incorrect'])
@@ -233,11 +233,11 @@ def summary(run_metrics, level='Total', columns=None, dtype='f4', ignore_missing
 
 
     >>> summary(run_metrics_example)
-    array([(0.36666667, 6.6666665, 0., 0., 0.)],
+    array([(0.37, 6.67, 0., 0., 0.)],
           dtype=[('Error Rate', '<f4'), ('First Cycle Intensity', '<f4'), ('Projected Yield G', '<f4'), ('Reads', '<f4'), ('Reads Pf', '<f4')])
 
     >>> summary(run_metrics_example, 'Total')
-    array([(0.36666667, 6.6666665, 0., 0., 0.)],
+    array([(0.37, 6.67, 0., 0., 0.)],
           dtype=[('Error Rate', '<f4'), ('First Cycle Intensity', '<f4'), ('Projected Yield G', '<f4'), ('Reads', '<f4'), ('Reads Pf', '<f4')])
 
     >>> summary(run_metrics_example, 'NonIndex')
@@ -261,16 +261,16 @@ def summary(run_metrics, level='Total', columns=None, dtype='f4', ignore_missing
 
     We can select specific columns using the `columns` parameter
     >>> summary(run_metrics_example, 'Total', columns=['First Cycle Intensity', 'Error Rate'])
-    array([(6.6666665, 0.36666667)],
+    array([(6.67, 0.37)],
           dtype=[('First Cycle Intensity', '<f4'), ('Error Rate', '<f4')])
 
     If a column values are NaN, or missing, then it will automatically be excluded
     >>> summary(run_metrics_example, 'Total', columns=['% Aligned', 'Error Rate'])
-    array([(0.36666667,)], dtype=[('Error Rate', '<f4')])
+     array([(0.37,)], dtype=[('Error Rate', '<f4')])
 
     To include missing columns, set `ignore_missing_columns=False`
     >>> summary(run_metrics_example, 'Total', ignore_missing_columns=False, columns=['% Aligned', 'Error Rate'])
-    array([(nan, 0.36666667)],
+    array([(nan, 0.37)],
           dtype=[('% Aligned', '<f4'), ('Error Rate', '<f4')])
 
     >>> summary(run_metrics_example, 'Total', columns=['Incorrect'])
@@ -513,18 +513,17 @@ def indexing(run_metrics, per_sample=True, dtype='f4', stype='O', **extra):
     We can also convert a `run_metrics` object to an indexing table as follows
     >>> ar = indexing(run_metrics_with_indexing)
     >>> ar
-    array([(1., 1101., 'ATCACGAC-AAGGTTCA', '1', 4570., 900., 507.77777),
-           (1., 1101., 'ATCACGAC-GGGGGGGG', '2', 2343., 900., 260.33334),
-           (1., 1102., 'ATCACGAC-AAGGTTCA', '1', 4570.,   0.,   0.     ),
-           (1., 1102., 'ATCACGAC-GGGGGGGG', '2', 2343.,   0.,   0.     )],
+    array([(1., 1101., 'ATCACGAC-AAGGTTCA', '1', 4570., 900., 507.78),
+           (1., 1101., 'ATCACGAC-GGGGGGGG', '2', 2343., 900., 260.33),
+           (1., 1102., 'ATCACGAC-AAGGTTCA', '1', 4570.,   0.,   0.  ),
+           (1., 1102., 'ATCACGAC-GGGGGGGG', '2', 2343.,   0.,   0.  )],
           dtype=[('Lane', '<f4'), ('Tile', '<f4'), ('Barcode', 'O'), ('SampleID', 'O'), ('Cluster Count', '<f4'), ('Cluster Count PF', '<f4'), ('% Demux', '<f4')])
 
     The `indexing` function also provides an overall sample view by setting `per_sample=False`.
 
     >>> ar = indexing(run_metrics_with_indexing, per_sample=False)
     >>> ar
-    array([(1., 1101., 1000., 900., 768.11115),
-           (1., 1102.,    0.,   0.,   0.     )],
+    array([(1., 1101., 1000., 900., 768.11), (1., 1102.,    0.,   0.,   0.  )],
           dtype=[('Lane', '<f4'), ('Tile', '<f4'), ('Cluster Count', '<f4'), ('Cluster Count PF', '<f4'), ('% Demux', '<f4')])
 
     :param run_metrics: py_interop_run_metrics.run_metrics or string run folder path

--- a/src/ext/python/core.py
+++ b/src/ext/python/core.py
@@ -1159,6 +1159,7 @@ def _run_doctests():
     import interop.core
     import doctest
     import sys
+    np.set_printoptions(precision=2)
     failure_count, test_count = doctest.testmod(interop.core
                                                 , optionflags=doctest.IGNORE_EXCEPTION_DETAIL
                                                 , globs=dict(

--- a/src/ext/python/setup.py.in
+++ b/src/ext/python/setup.py.in
@@ -44,8 +44,8 @@ setup(
     ],
     keywords="Illumina sequencer HiSeqX HiSeq NextSeq MiniSeq NovaSeq MiSeq SBS genome",
     install_requires=[
-        'numpy>=1.16.6;python_version>="3.5"',
-        'numpy==1.16.6;python_version<"3.5"',
+        'numpy>=1.23.3;python_version>="3.9"',
+        'numpy>=1.16.6,<2.0;python_version<="3.8"',
     ],
     distclass=BinaryDistribution,
     cmdclass={'install': InstallPlatlib},

--- a/src/ext/python/setup.py.in
+++ b/src/ext/python/setup.py.in
@@ -44,7 +44,10 @@ setup(
     ],
     keywords="Illumina sequencer HiSeqX HiSeq NextSeq MiniSeq NovaSeq MiSeq SBS genome",
     install_requires=[
-        'numpy>=1.23.3;python_version>="3.9"',
+        'numpy>=1.26.2;python_version>="3.12"',
+        'numpy>=1.23.2;python_version>="3.11"',
+        'numpy>=1.21.6;python_version>="3.10"',
+        'numpy>=1.19.3;python_version>="3.9"',
         'numpy>=1.16.6,<2.0;python_version<="3.8"',
     ],
     distclass=BinaryDistribution,

--- a/src/tests/interop/logic/summary_metrics_test.cpp
+++ b/src/tests/interop/logic/summary_metrics_test.cpp
@@ -184,7 +184,7 @@ TEST_P(run_summary_tests, lane_summary)
     const float density_tol = 0.5f;
     const float tol = 1e-2f; // TODO: fix this unit test on external Windows Builds (appveyor) was 1e-7f
 #else
-    const float density_tol = 1e-7f;
+    const float density_tol = 1e-2f;
     const float tol = 1e-7f;
 #endif
     ASSERT_EQ(actual.size(), expected.size());

--- a/src/tests/python/CoreTests.py
+++ b/src/tests/python/CoreTests.py
@@ -152,7 +152,7 @@ class CoreTests(unittest.TestCase):
             ,7,0,90,4,1,0,-12,-56,15,64,-98,35,12,64,0,0,0,0,0,0,0,0,46,1,17,1,0,0,0,0,96,-41,-104,36,122,-86,-46,-120
             ,7,0,-66,4,1,0,96,-43,14,64,-63,49,13,64,0,0,0,0,0,0,0,0,56,1,17,1,0,0,0,0,112,125,77,38,122,-86,-46,-120
             ,7,0,66,8,1,0,74,-68,6,64,-118,-7,8,64,0,0,0,0,0,0,0,0,93,1,46,1,0,0,0,0,-47,-104,2,40,122,-86,-46,-120],
-            dtype=numpy.uint8)
+            dtype=numpy.uint8, casting='unsafe')
         run = py_interop_run_metrics.run_metrics()
         try:
             py_interop_comm.read_interop_from_buffer(tmp, run.extraction_metric_set())
@@ -170,7 +170,7 @@ class CoreTests(unittest.TestCase):
                 ,7,0,90,4,1,0,-12,-56,15,64,-98,35,12,64,0,0,0,0,0,0,0,0,46,1,17,1,0,0,0,0,96,-41,-104,36,122,-86,-46,-120
                 ,7,0,-66,4,1,0,96,-43,14,64,-63,49,13,64,0,0,0,0,0,0,0,0,56,1,17,1,0,0,0,0,112,125,77,38,122,-86,-46,-120
                 ,7,0,66,8,1,0,74,-68,6,64,-118,-7,8,64,0,0,0,0,0,0,0,0,93,1,46,1,0,0,0,0,-47,-104,2,40,122,-86,-46,-120],
-            dtype=numpy.uint8)
+            dtype=numpy.uint8, casting='unsafe')
         run = py_interop_run_metrics.run_metrics()
         try:
             py_interop_comm.read_interop_from_buffer(tmp, run.extraction_metric_set())
@@ -188,7 +188,7 @@ class CoreTests(unittest.TestCase):
                 ,7,0,90,4,1,0,-12,-56,15,64,-98,35,12,64,0,0,0,0,0,0,0,0,46,1,17,1,0,0,0,0,96,-41,-104,36,122,-86,-46,-120
                 ,7,0,-66,4,1,0,96,-43,14,64,-63,49,13,64,0,0,0,0,0,0,0,0,56,1,17,1,0,0,0,0,112,125,77,38,122,-86,-46,-120
                 ,7,0,66,8,1,0,74,-68,6,64,-118,-7,8,64,0,0,0,0,0,0,0,0,93,1,46,1,0,0,0,0,-47,-104,2,40,122,-86,-46,-120],
-                dtype=numpy.uint8)
+                dtype=numpy.uint8, casting='unsafe')
         run = py_interop_run_metrics.run_metrics()
         py_interop_comm.read_interop_from_buffer(tmp, run.extraction_metric_set())
         try:
@@ -208,7 +208,7 @@ class CoreTests(unittest.TestCase):
                 ,7,0,90,4,1,0,-12,-56,15,64,-98,35,12,64,0,0,0,0,0,0,0,0,46,1,17,1,0,0,0,0,96,-41,-104,36,122,-86,-46,-120
                 ,7,0,-66,4,1,0,96,-43,14,64,-63,49,13,64,0,0,0,0,0,0,0,0,56,1,17,1,0,0,0,0,112,125,77,38,122,-86,-46,-120
                 ,7,0,66,8,1,0,74,-68,6,64,-118,-7,8,64,0,0,0,0,0,0,0,0,93,1,46,1,0,0,0,0,-47,-104,2,40,122,-86,-46,-120],
-            dtype=numpy.uint8)
+            dtype=numpy.uint8, casting='unsafe')
         run = py_interop_run_metrics.run_metrics()
         run.read_metrics_from_buffer(py_interop_run.Extraction, tmp)
         try:
@@ -355,7 +355,7 @@ class CoreTests(unittest.TestCase):
             ,7,0,90,4,1,0,-12,-56,15,64,-98,35,12,64,0,0,0,0,0,0,0,0,46,1,17,1,0,0,0,0,96,-41,-104,36,122,-86,-46,-120
             ,7,0,-66,4,1,0,96,-43,14,64,-63,49,13,64,0,0,0,0,0,0,0,0,56,1,17,1,0,0,0,0,112,125,77,38,122,-86,-46,-120
             ,7,0,66,8,1,0,74,-68,6,64,-118,-7,8,64,0,0,0,0,0,0,0,0,93,1,46,1,0,0,0,0,-47,-104,2,40,122,-86,-46,-120],
-                            dtype=numpy.uint8)
+                            dtype=numpy.uint8, casting='unsafe')
         run = py_interop_run_metrics.run_metrics()
         py_interop_comm.read_interop_from_buffer(tmp, run.extraction_metric_set())
         self.assertEqual(run.extraction_metric_set().size(), 3)

--- a/src/tests/python/CoreTests.py
+++ b/src/tests/python/CoreTests.py
@@ -152,7 +152,7 @@ class CoreTests(unittest.TestCase):
             ,7,0,90,4,1,0,-12,-56,15,64,-98,35,12,64,0,0,0,0,0,0,0,0,46,1,17,1,0,0,0,0,96,-41,-104,36,122,-86,-46,-120
             ,7,0,-66,4,1,0,96,-43,14,64,-63,49,13,64,0,0,0,0,0,0,0,0,56,1,17,1,0,0,0,0,112,125,77,38,122,-86,-46,-120
             ,7,0,66,8,1,0,74,-68,6,64,-118,-7,8,64,0,0,0,0,0,0,0,0,93,1,46,1,0,0,0,0,-47,-104,2,40,122,-86,-46,-120],
-            dtype=numpy.uint8, casting='unsafe')
+            dtype=numpy.int8).astype(dtype=numpy.uint8, casting='unsafe')
         run = py_interop_run_metrics.run_metrics()
         try:
             py_interop_comm.read_interop_from_buffer(tmp, run.extraction_metric_set())
@@ -170,7 +170,7 @@ class CoreTests(unittest.TestCase):
                 ,7,0,90,4,1,0,-12,-56,15,64,-98,35,12,64,0,0,0,0,0,0,0,0,46,1,17,1,0,0,0,0,96,-41,-104,36,122,-86,-46,-120
                 ,7,0,-66,4,1,0,96,-43,14,64,-63,49,13,64,0,0,0,0,0,0,0,0,56,1,17,1,0,0,0,0,112,125,77,38,122,-86,-46,-120
                 ,7,0,66,8,1,0,74,-68,6,64,-118,-7,8,64,0,0,0,0,0,0,0,0,93,1,46,1,0,0,0,0,-47,-104,2,40,122,-86,-46,-120],
-            dtype=numpy.uint8, casting='unsafe')
+            dtype=numpy.int8).astype(dtype=numpy.uint8, casting='unsafe')
         run = py_interop_run_metrics.run_metrics()
         try:
             py_interop_comm.read_interop_from_buffer(tmp, run.extraction_metric_set())
@@ -188,7 +188,7 @@ class CoreTests(unittest.TestCase):
                 ,7,0,90,4,1,0,-12,-56,15,64,-98,35,12,64,0,0,0,0,0,0,0,0,46,1,17,1,0,0,0,0,96,-41,-104,36,122,-86,-46,-120
                 ,7,0,-66,4,1,0,96,-43,14,64,-63,49,13,64,0,0,0,0,0,0,0,0,56,1,17,1,0,0,0,0,112,125,77,38,122,-86,-46,-120
                 ,7,0,66,8,1,0,74,-68,6,64,-118,-7,8,64,0,0,0,0,0,0,0,0,93,1,46,1,0,0,0,0,-47,-104,2,40,122,-86,-46,-120],
-                dtype=numpy.uint8, casting='unsafe')
+                dtype=numpy.int8).astype(dtype=numpy.uint8, casting='unsafe')
         run = py_interop_run_metrics.run_metrics()
         py_interop_comm.read_interop_from_buffer(tmp, run.extraction_metric_set())
         try:
@@ -208,7 +208,7 @@ class CoreTests(unittest.TestCase):
                 ,7,0,90,4,1,0,-12,-56,15,64,-98,35,12,64,0,0,0,0,0,0,0,0,46,1,17,1,0,0,0,0,96,-41,-104,36,122,-86,-46,-120
                 ,7,0,-66,4,1,0,96,-43,14,64,-63,49,13,64,0,0,0,0,0,0,0,0,56,1,17,1,0,0,0,0,112,125,77,38,122,-86,-46,-120
                 ,7,0,66,8,1,0,74,-68,6,64,-118,-7,8,64,0,0,0,0,0,0,0,0,93,1,46,1,0,0,0,0,-47,-104,2,40,122,-86,-46,-120],
-            dtype=numpy.uint8, casting='unsafe')
+            dtype=numpy.int8).astype(dtype=numpy.uint8, casting='unsafe')
         run = py_interop_run_metrics.run_metrics()
         run.read_metrics_from_buffer(py_interop_run.Extraction, tmp)
         try:
@@ -355,7 +355,7 @@ class CoreTests(unittest.TestCase):
             ,7,0,90,4,1,0,-12,-56,15,64,-98,35,12,64,0,0,0,0,0,0,0,0,46,1,17,1,0,0,0,0,96,-41,-104,36,122,-86,-46,-120
             ,7,0,-66,4,1,0,96,-43,14,64,-63,49,13,64,0,0,0,0,0,0,0,0,56,1,17,1,0,0,0,0,112,125,77,38,122,-86,-46,-120
             ,7,0,66,8,1,0,74,-68,6,64,-118,-7,8,64,0,0,0,0,0,0,0,0,93,1,46,1,0,0,0,0,-47,-104,2,40,122,-86,-46,-120],
-                            dtype=numpy.uint8, casting='unsafe')
+                            dtype=numpy.int8).astype(dtype=numpy.uint8, casting='unsafe')
         run = py_interop_run_metrics.run_metrics()
         py_interop_comm.read_interop_from_buffer(tmp, run.extraction_metric_set())
         self.assertEqual(run.extraction_metric_set().size(), 3)

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -198,7 +198,9 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
       echo "Found Miniconda"
     fi
 
-    conda init --all
+    if hash conda 2> /dev/null; then
+      conda init --all
+    fi
     source ~/.bash_profile
     for py_ver in $python_versions ; do
         echo "Building Python $py_ver - $CFLAGS"
@@ -223,17 +225,12 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
           conda install wheel -y --name py${python_version}
           conda install pandas -y --name py${python_version}
 
-        elif hash pyenv 2> /dev/null; then
-            export PATH=$(pyenv root)/shims:${PATH}
+        else
             if [[ "$OSTYPE" == "linux-gnu" ]]; then
                 if hash patchelf 2> /dev/null; then
-                    pyenv install 3.5 -s  || true
-                    pyenv global 3.5 || true
-                    pip3 install auditwheel==1.5
+                    python -m pip install auditwheel==1.5
                 fi
             fi
-            pyenv install $py_ver -s
-            pyenv global $py_ver
             if [[ "$OSTYPE" == "darwin"* ]]; then
                 pip install setuptools==43.0.0
                 pip install delocate

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -254,10 +254,10 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
         fi
         pip install swig --prefix ./usr
         swig_bin=$(ls ./usr/lib/python3.*/site-packages/swig/data/bin/swig)
-        swig_path=$(dirname $swig_bin)
-        swig_dir=$(dirname $swig_path)
-        export SWIG_DIR=${swig_dir}
-        run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp -DSWIG_DIR=${swig_dir} -DSWIG_EXECUTABLE=${swig_bin}
+        #swig_path=$(dirname $swig_bin)
+        #swig_dir=$(dirname $swig_path)
+        #export SWIG_DIR=${swig_dir}
+        run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp -DSWIG_EXECUTABLE=${swig_bin}
         run "Build $py_ver" cmake --build $BUILD_PATH -- -j${THREAD_COUNT}
         run "Test $py_ver" cmake --build $BUILD_PATH --target check_python -- -j${THREAD_COUNT}
         run "Build Wheel $py_ver" cmake --build $BUILD_PATH --target package_wheel -- -j${THREAD_COUNT}

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -253,10 +253,15 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
             python -c "import wheel"
             # pip install wheel=0.30.0
         fi
-        pip install swig==4.0.2 --prefix=$(pwd)/usr
-        swig_bin=$(ls ./usr/lib/python3.*/site-packages/swig/data/bin/swig)
+        pip install swig==4.0.2 --prefix="$(pwd)/usr"
+        # ./usr/lib/python3.9/site-packages/swig/data/share/swig/4.0.2/
+        swig_bin=$(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/bin/swig)
         swig_path=$(dirname $swig_bin)
         swig_dir=$(dirname $swig_path)/share/swig/4.0.2/
+       ${swig_bin} -version
+        echo "${swig_bin}"
+        echo "${swig_dir}"
+        ls ${swig_dir}
         run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp -DSWIG_EXECUTABLE=${swig_bin} -DSWIG_DIR=${swig_dir}
         run "Build $py_ver" cmake --build $BUILD_PATH -- -j${THREAD_COUNT}
         run "Test $py_ver" cmake --build $BUILD_PATH --target check_python -- -j${THREAD_COUNT}

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -252,6 +252,8 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
             python -c "import wheel"
             # pip install wheel=0.30.0
         fi
+        pip install swig --prefix ./usr
+        export PATH=$(pwd)/usr/bin:$PATH
         run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp
         run "Build $py_ver" cmake --build $BUILD_PATH -- -j${THREAD_COUNT}
         run "Test $py_ver" cmake --build $BUILD_PATH --target check_python -- -j${THREAD_COUNT}

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -256,6 +256,7 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
         swig_bin=$(ls ./usr/lib/python3.*/site-packages/swig/data/bin/swig)
         swig_path=$(dirname $swig_bin)
         export PATH=${swig_path}:$PATH
+        export SWIG_DIR=${swig_path}/../share
         run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp
         run "Build $py_ver" cmake --build $BUILD_PATH -- -j${THREAD_COUNT}
         run "Test $py_ver" cmake --build $BUILD_PATH --target check_python -- -j${THREAD_COUNT}

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -255,8 +255,9 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
         pip install swig --prefix ./usr
         swig_bin=$(ls ./usr/lib/python3.*/site-packages/swig/data/bin/swig)
         swig_path=$(dirname $swig_bin)
+        swig_dir=$(dirname $swig_path)
         export PATH=${swig_path}:$PATH
-        export SWIG_DIR=${swig_path}/..
+        export SWIG_DIR=${swig_dir}/share
         run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp
         run "Build $py_ver" cmake --build $BUILD_PATH -- -j${THREAD_COUNT}
         run "Test $py_ver" cmake --build $BUILD_PATH --target check_python -- -j${THREAD_COUNT}

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -256,9 +256,7 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
         swig_bin=$(ls ./usr/lib/python3.*/site-packages/swig/data/bin/swig)
         swig_path=$(dirname $swig_bin)
         swig_dir=$(dirname $swig_path)
-        export PATH=${swig_path}:$PATH
-        export SWIG_DIR=${swig_dir}/share
-        run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp
+        run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp -DSWIG_DIR=${swig_dir} -DSWIG_EXECUTABLE=${swig_bin}
         run "Build $py_ver" cmake --build $BUILD_PATH -- -j${THREAD_COUNT}
         run "Test $py_ver" cmake --build $BUILD_PATH --target check_python -- -j${THREAD_COUNT}
         run "Build Wheel $py_ver" cmake --build $BUILD_PATH --target package_wheel -- -j${THREAD_COUNT}

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -231,16 +231,13 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
                     python -m pip install auditwheel==1.5
                 fi
             fi
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-                pip install setuptools==43.0.0
-                pip install delocate
-                # pip install delocate=0.7.3
-            fi
             which python
             which pip
+            pip install delocate || true
             python --version
             pip install numpy
             pip install wheel
+            pip install setuptools
             echo "Check setuptools"
             python -c "import setuptools"
             echo "Check numpy"

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -256,7 +256,7 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
         swig_bin=$(ls ./usr/lib/python3.*/site-packages/swig/data/bin/swig)
         swig_path=$(dirname $swig_bin)
         export PATH=${swig_path}:$PATH
-        export SWIG_DIR=${swig_path}/../share
+        export SWIG_DIR=${swig_path}/..
         run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp
         run "Build $py_ver" cmake --build $BUILD_PATH -- -j${THREAD_COUNT}
         run "Test $py_ver" cmake --build $BUILD_PATH --target check_python -- -j${THREAD_COUNT}

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -253,7 +253,9 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
             # pip install wheel=0.30.0
         fi
         pip install swig --prefix ./usr
-        export PATH=$(pwd)/usr/bin:$PATH
+        swig_bin=$(ls tmp/lib/python3.*/site-packages/swig/data/bin/swig)
+        swig_path=$(dirname $swig_bin)
+        export PATH=${swig_path}:$PATH
         run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp
         run "Build $py_ver" cmake --build $BUILD_PATH -- -j${THREAD_COUNT}
         run "Test $py_ver" cmake --build $BUILD_PATH --target check_python -- -j${THREAD_COUNT}

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -253,7 +253,7 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
             # pip install wheel=0.30.0
         fi
         pip install swig --prefix ./usr
-        swig_bin=$(ls tmp/lib/python3.*/site-packages/swig/data/bin/swig)
+        swig_bin=$(ls ./usr/lib/python3.*/site-packages/swig/data/bin/swig)
         swig_path=$(dirname $swig_bin)
         export PATH=${swig_path}:$PATH
         run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -254,14 +254,12 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
             # pip install wheel=0.30.0
         fi
         pip install swig==4.0.2 --prefix="$(pwd)/usr"
-        # ./usr/lib/python3.9/site-packages/swig/data/share/swig/4.0.2/
         swig_bin=$(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/bin/swig)
         swig_path=$(dirname $swig_bin)
         swig_dir=$(dirname $swig_path)/share/swig/4.0.2/
-       ${swig_bin} -version
+        ${swig_bin} -version
         echo "${swig_bin}"
         echo "${swig_dir}"
-        ls ${swig_dir}
         run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp -DSWIG_EXECUTABLE=${swig_bin} -DSWIG_DIR=${swig_dir}
         run "Build $py_ver" cmake --build $BUILD_PATH -- -j${THREAD_COUNT}
         run "Test $py_ver" cmake --build $BUILD_PATH --target check_python -- -j${THREAD_COUNT}
@@ -296,7 +294,11 @@ if [ "$PYTHON_VERSION" == "DotNetStandard" ] || [ "$PYTHON_VERSION" == "" ] ; th
   # Workaround for OSX
   export PATH=/usr/local/share/dotnet:${PATH}
   if hash dotnet 2> /dev/null; then
-      run "Configure DotNetStandard" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DCSBUILD_TOOL=DotNetStandard -DENABLE_PYTHON=OFF
+      pip install swig==4.0.2 --prefix="$(pwd)/usr"
+      swig_bin=$(ls $(pwd)/usr/lib/python3.*/site-packages/swig/data/bin/swig)
+      swig_path=$(dirname $swig_bin)
+      swig_dir=$(dirname $swig_path)/share/swig/4.0.2/
+      run "Configure DotNetStandard" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DCSBUILD_TOOL=DotNetStandard -DENABLE_PYTHON=OFF  -DSWIG_EXECUTABLE=${swig_bin} -DSWIG_DIR=${swig_dir}
       run "Test DotNetStandard" cmake --build $BUILD_PATH --target check -- -j${THREAD_COUNT}
       run "Package DotNetStandard" cmake --build $BUILD_PATH --target nupack -- -j${THREAD_COUNT}
   fi

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -167,11 +167,11 @@ if [  -e /opt/python ] ; then
           rm -fr ${ARTIFACT_PATH}/tmp
       done
     else
-        /opt/python/cp38-cp38/bin/python -m pip install numpy==1.17.3
-        /opt/python/cp39-cp39/bin/python -m pip install numpy==2.0.0
-        /opt/python/cp310-cp310/bin/python -m pip install numpy==2.0.0
-        /opt/python/cp311-cp311/bin/python -m pip install numpy==2.0.0
-        /opt/python/cp312-cp312/bin/python -m pip install numpy==2.0.0
+        /opt/python/cp38-cp38/bin/python -m pip install numpy==1.17.3 pandas
+        /opt/python/cp39-cp39/bin/python -m pip install numpy==2.0.0 pandas
+        /opt/python/cp310-cp310/bin/python -m pip install numpy==2.0.0 pandas
+        /opt/python/cp311-cp311/bin/python -m pip install numpy==2.0.0 pandas
+        /opt/python/cp312-cp312/bin/python -m pip install numpy==2.0.0 pandas
 
           echo "Build with specific Python Version: ${PYTHON_VERSION}"
           PYTHON_BIN=/opt/python/${PYTHON_VERSION}/bin

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -253,12 +253,11 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
             python -c "import wheel"
             # pip install wheel=0.30.0
         fi
-        pip install swig --prefix ./usr
+        pip install swig==4.0.2 --prefix=$(pwd)/usr
         swig_bin=$(ls ./usr/lib/python3.*/site-packages/swig/data/bin/swig)
-        #swig_path=$(dirname $swig_bin)
-        #swig_dir=$(dirname $swig_path)
-        #export SWIG_DIR=${swig_dir}
-        run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp -DSWIG_EXECUTABLE=${swig_bin}
+        swig_path=$(dirname $swig_bin)
+        swig_dir=$(dirname $swig_path)/share/swig/4.0.2/
+        run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp -DSWIG_EXECUTABLE=${swig_bin} -DSWIG_DIR=${swig_dir}
         run "Build $py_ver" cmake --build $BUILD_PATH -- -j${THREAD_COUNT}
         run "Test $py_ver" cmake --build $BUILD_PATH --target check_python -- -j${THREAD_COUNT}
         run "Build Wheel $py_ver" cmake --build $BUILD_PATH --target package_wheel -- -j${THREAD_COUNT}

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -167,7 +167,13 @@ if [  -e /opt/python ] ; then
           rm -fr ${ARTIFACT_PATH}/tmp
       done
     else
-        echo "Build with specific Python Version: ${PYTHON_VERSION}"
+        /opt/python/cp38-cp38/bin/python -m pip install numpy==1.17.3
+        /opt/python/cp39-cp39/bin/python -m pip install numpy==2.0.0
+        /opt/python/cp310-cp310/bin/python -m pip install numpy==2.0.0
+        /opt/python/cp311-cp311/bin/python -m pip install numpy==2.0.0
+        /opt/python/cp312-cp312/bin/python -m pip install numpy==2.0.0
+
+          echo "Build with specific Python Version: ${PYTHON_VERSION}"
           PYTHON_BIN=/opt/python/${PYTHON_VERSION}/bin
           rm -fr ${BUILD_PATH}/src/ext/python/*
           run "Configure ${PYTHON_VERSION}" cmake $SOURCE_PATH -B${BUILD_PATH} -DPython_EXECUTABLE=${PYTHON_BIN}/python ${CMAKE_EXTRA_FLAGS} -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp -DENABLE_CSHARP=OFF

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -256,6 +256,7 @@ elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PY
         swig_bin=$(ls ./usr/lib/python3.*/site-packages/swig/data/bin/swig)
         swig_path=$(dirname $swig_bin)
         swig_dir=$(dirname $swig_path)
+        export SWIG_DIR=${swig_dir}
         run "Configure $py_ver" cmake $SOURCE_PATH -B${BUILD_PATH} ${CMAKE_EXTRA_FLAGS} -DENABLE_CSHARP=OFF -DENABLE_PYTHON_DYNAMIC_LOAD=ON -DPython_EXECUTABLE=`which python` -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp -DSWIG_DIR=${swig_dir} -DSWIG_EXECUTABLE=${swig_bin}
         run "Build $py_ver" cmake --build $BUILD_PATH -- -j${THREAD_COUNT}
         run "Test $py_ver" cmake --build $BUILD_PATH --target check_python -- -j${THREAD_COUNT}

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -172,11 +172,12 @@ if [  -e /opt/python ] ; then
         /opt/python/cp310-cp310/bin/python -m pip install numpy==2.0.0 pandas
         /opt/python/cp311-cp311/bin/python -m pip install numpy==2.0.0 pandas
         /opt/python/cp312-cp312/bin/python -m pip install numpy==2.0.0 pandas
+        /opt/python/cp310-cp310/bin/python -m pip install swig==4.0.2 --prefix=/tmp/usr
 
           echo "Build with specific Python Version: ${PYTHON_VERSION}"
           PYTHON_BIN=/opt/python/${PYTHON_VERSION}/bin
           rm -fr ${BUILD_PATH}/src/ext/python/*
-          run "Configure ${PYTHON_VERSION}" cmake $SOURCE_PATH -B${BUILD_PATH} -DPython_EXECUTABLE=${PYTHON_BIN}/python ${CMAKE_EXTRA_FLAGS} -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp -DENABLE_CSHARP=OFF
+          run "Configure ${PYTHON_VERSION}" cmake $SOURCE_PATH -B${BUILD_PATH} -DPython_EXECUTABLE=${PYTHON_BIN}/python ${CMAKE_EXTRA_FLAGS} -DSKIP_PACKAGE_ALL_WHEEL=ON -DPYTHON_WHEEL_PREFIX=${ARTIFACT_PATH}/tmp -DENABLE_CSHARP=OFF -DSWIG_EXECUTABLE=/tmp/usr/lib/python3.10/site-packages/swig/data/bin/swig  -DSWIG_DIR=/tmp/usr/lib/python3.10/site-packages/swig/data/share/swig/4.0.2/
 
           run "Test ${PYTHON_VERSION}" cmake --build $BUILD_PATH --target check -- -j${THREAD_COUNT}
           run "Build ${PYTHON_VERSION}" cmake --build $BUILD_PATH --target package_wheel -- -j${THREAD_COUNT}

--- a/tools/prereqs/docker-centos7-install.sh
+++ b/tools/prereqs/docker-centos7-install.sh
@@ -50,11 +50,11 @@ yum install -y wget libicu
 mkdir /opt/dotnet
 wget --no-check-certificate --quiet -O - ${DOTNET_URL} | tar --strip-components=1 -xz -C /opt/dotnet
 
-if hash cmake  2> /dev/null; then
-    wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C /opt/_internal/tools
-else
-    wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C /usr
-fi
+#if hash cmake  2> /dev/null; then
+#    wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C /opt/_internal/tools
+#else
+#    wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C /usr
+#fi
 
 if hash mono  2> /dev/null; then
     echo "Found mono"
@@ -140,13 +140,11 @@ wget --no-check-certificate --quiet ${NUGET_URL} -O /usr/lib/nuget.exe
 echo "mono /usr/lib/nuget.exe \$@" > /usr/bin/nuget
 chmod +x /usr/bin/nuget
 
-        /opt/python/cp38-cp38/bin/python -m pip install numpy==1.17.3 pandas
-        /opt/python/cp39-cp39/bin/python -m pip install numpy==2.0.0 pandas
-        /opt/python/cp310-cp310/bin/python -m pip install numpy==2.0.0 pandas
-        /opt/python/cp311-cp311/bin/python -m pip install numpy==2.0.0 pandas
-        /opt/python/cp312-cp312/bin/python -m pip install numpy==2.0.0 pandas
-
-
+/opt/python/cp38-cp38/bin/python -m pip install numpy==1.17.3 pandas
+/opt/python/cp39-cp39/bin/python -m pip install numpy==2.0.0 pandas
+/opt/python/cp310-cp310/bin/python -m pip install numpy==2.0.0 pandas
+/opt/python/cp311-cp311/bin/python -m pip install numpy==2.0.0 pandas
+/opt/python/cp312-cp312/bin/python -m pip install numpy==2.0.0 pandas
 
 export JAVA_HOME=/usr/java/jdk1.8.0_131
 export PATH=${PATH}:/opt/dotnet

--- a/tools/prereqs/docker-centos7-install.sh
+++ b/tools/prereqs/docker-centos7-install.sh
@@ -39,8 +39,9 @@ SWIG_HOME=${PROG_HOME}/swig4
 JUNIT_HOME=${PROG_HOME}/junit
 NUNIT_HOME=${PROG_HOME}/nunit
 
-#sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-#sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+yum install -y wget
 #yum -y update
 #yum install -y wget which libunwind lttng-ust libcurl openssl-libs libuuid krb5-libs libicu zlib
 #yum install -y gcc gcc-c++ libtool git make rpm-build

--- a/tools/prereqs/docker-centos7-install.sh
+++ b/tools/prereqs/docker-centos7-install.sh
@@ -39,10 +39,12 @@ SWIG_HOME=${PROG_HOME}/swig4
 JUNIT_HOME=${PROG_HOME}/junit
 NUNIT_HOME=${PROG_HOME}/nunit
 
+#sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+#sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 #yum -y update
-yum install -y wget which libunwind lttng-ust libcurl openssl-libs libuuid krb5-libs libicu zlib
-yum install -y gcc gcc-c++ libtool git make rpm-build
-yum install -y python-devel
+#yum install -y wget which libunwind lttng-ust libcurl openssl-libs libuuid krb5-libs libicu zlib
+#yum install -y gcc gcc-c++ libtool git make rpm-build
+#yum install -y python-devel
 
 mkdir /opt/dotnet
 wget --no-check-certificate --quiet -O - ${DOTNET_URL} | tar --strip-components=1 -xz -C /opt/dotnet

--- a/tools/prereqs/docker-centos7-install.sh
+++ b/tools/prereqs/docker-centos7-install.sh
@@ -140,9 +140,12 @@ wget --no-check-certificate --quiet ${NUGET_URL} -O /usr/lib/nuget.exe
 echo "mono /usr/lib/nuget.exe \$@" > /usr/bin/nuget
 chmod +x /usr/bin/nuget
 
-    for PYBUILD in `ls -1 /opt/python`; do
-        "/opt/python/${PYBUILD}/bin/pip" install numpy pandas
-    done
+        /opt/python/cp38-cp38/bin/python -m pip install numpy==1.17.3 pandas
+        /opt/python/cp39-cp39/bin/python -m pip install numpy==2.0.0 pandas
+        /opt/python/cp310-cp310/bin/python -m pip install numpy==2.0.0 pandas
+        /opt/python/cp311-cp311/bin/python -m pip install numpy==2.0.0 pandas
+        /opt/python/cp312-cp312/bin/python -m pip install numpy==2.0.0 pandas
+
 
 
 export JAVA_HOME=/usr/java/jdk1.8.0_131

--- a/tools/prereqs/docker-centos7-install.sh
+++ b/tools/prereqs/docker-centos7-install.sh
@@ -41,7 +41,7 @@ NUNIT_HOME=${PROG_HOME}/nunit
 
 sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-yum install -y wget
+yum install -y wget libicu
 #yum -y update
 #yum install -y wget which libunwind lttng-ust libcurl openssl-libs libuuid krb5-libs libicu zlib
 #yum install -y gcc gcc-c++ libtool git make rpm-build


### PR DESCRIPTION
Resolves #348
Resolves #340
Resolves #339
Resolves #338

- Pin swig to 4.0.2 to work around bug in some later version of swig.
- Add Python 3.12
- Make Python 3.8 the minimum supported version
- Fix Python unit tests to support numpy==2.0.0
- Upgrade to netcoreapp7 on Mac