### PR TITLE
Add ARM64 (aarch64) Linux support for Python wheels

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,7 +2,7 @@ name: Python Wheels
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 10.9
-  DOCKER_IMAGE: quay.io/pypa/manylinux2014_x86_64
+  DOCKER_IMAGE_PREFIX: quay.io/pypa/manylinux2014
 
 on:
   push:
@@ -18,6 +18,36 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         pyver: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        arch: ['x86_64']
+        include:
+          # Add ARM64 builds for Linux
+          - os: ubuntu-latest
+            pyver: '3.8'
+            arch: 'aarch64'
+          - os: ubuntu-latest
+            pyver: '3.9'
+            arch: 'aarch64'
+          - os: ubuntu-latest
+            pyver: '3.10'
+            arch: 'aarch64'
+          - os: ubuntu-latest
+            pyver: '3.11'
+            arch: 'aarch64'
+          - os: ubuntu-latest
+            pyver: '3.12'
+            arch: 'aarch64'
+          - os: ubuntu-latest
+            pyver: '3.13'
+            arch: 'aarch64'
+          - os: ubuntu-latest
+            pyver: '3.14'
+            arch: 'aarch64'
+        exclude:
+          # Exclude ARM64 from non-Linux platforms in the base matrix
+          - os: windows-latest
+            arch: 'aarch64'
+          - os: macOS-latest
+            arch: 'aarch64'
 
     steps:
       - uses: actions/checkout@v3
@@ -36,33 +66,39 @@ jobs:
           git config user.email "<>"
           git --version
 
-      - name: Package Python 3.8 and earlier
+      - name: Set up QEMU for ARM64 emulation
+        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.arch == 'aarch64' }}
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Package Python 3.8
         if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.pyver == '3.8' }}
-        run: docker run --rm -v ${{github.workspace}}/:/io ezralanglois/interop sh /io/tools/package.sh /io /io/dist travis OFF
+        run: docker run --rm --platform linux/${{ matrix.arch == 'aarch64' && 'arm64' || 'amd64' }} -v ${{github.workspace}}/:/io ${DOCKER_IMAGE_PREFIX}_${{ matrix.arch }} sh /io/tools/package.sh /io /io/dist travis OFF Release cp38-cp38
 
       - name: Package Python 3.9
         if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.pyver == '3.9' }}
-        run: docker run --rm -v ${{github.workspace}}/:/io $DOCKER_IMAGE sh /io/tools/package.sh /io /io/dist travis OFF Release cp39-cp39
+        run: docker run --rm --platform linux/${{ matrix.arch == 'aarch64' && 'arm64' || 'amd64' }} -v ${{github.workspace}}/:/io ${DOCKER_IMAGE_PREFIX}_${{ matrix.arch }} sh /io/tools/package.sh /io /io/dist travis OFF Release cp39-cp39
 
       - name: Package Python 3.10
         if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.pyver == '3.10' }}
-        run: docker run --rm -v ${{github.workspace}}/:/io $DOCKER_IMAGE sh /io/tools/package.sh /io /io/dist travis OFF Release cp310-cp310
+        run: docker run --rm --platform linux/${{ matrix.arch == 'aarch64' && 'arm64' || 'amd64' }} -v ${{github.workspace}}/:/io ${DOCKER_IMAGE_PREFIX}_${{ matrix.arch }} sh /io/tools/package.sh /io /io/dist travis OFF Release cp310-cp310
 
       - name: Package Python 3.11
         if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.pyver == '3.11' }}
-        run: docker run --rm -v ${{github.workspace}}/:/io $DOCKER_IMAGE sh /io/tools/package.sh /io /io/dist travis OFF Release cp311-cp311
+        run: docker run --rm --platform linux/${{ matrix.arch == 'aarch64' && 'arm64' || 'amd64' }} -v ${{github.workspace}}/:/io ${DOCKER_IMAGE_PREFIX}_${{ matrix.arch }} sh /io/tools/package.sh /io /io/dist travis OFF Release cp311-cp311
 
       - name: Package Python 3.12
         if: ${{ startsWith(matrix.os, 'ubuntu') &&  matrix.pyver == '3.12' }}
-        run: docker run --rm -v ${{github.workspace}}/:/io $DOCKER_IMAGE sh /io/tools/package.sh /io /io/dist travis OFF Release cp312-cp312
+        run: docker run --rm --platform linux/${{ matrix.arch == 'aarch64' && 'arm64' || 'amd64' }} -v ${{github.workspace}}/:/io ${DOCKER_IMAGE_PREFIX}_${{ matrix.arch }} sh /io/tools/package.sh /io /io/dist travis OFF Release cp312-cp312
 
       - name: Package Python 3.13
         if: ${{ startsWith(matrix.os, 'ubuntu') &&  matrix.pyver == '3.13' }}
-        run: docker run --rm -v ${{github.workspace}}/:/io $DOCKER_IMAGE sh /io/tools/package.sh /io /io/dist travis OFF Release cp313-cp313
+        run: docker run --rm --platform linux/${{ matrix.arch == 'aarch64' && 'arm64' || 'amd64' }} -v ${{github.workspace}}/:/io ${DOCKER_IMAGE_PREFIX}_${{ matrix.arch }} sh /io/tools/package.sh /io /io/dist travis OFF Release cp313-cp313
 
       - name: Package Python 3.14
         if: ${{ startsWith(matrix.os, 'ubuntu') &&  matrix.pyver == '3.14' }}
-        run: docker run --rm -v ${{github.workspace}}/:/io $DOCKER_IMAGE sh /io/tools/package.sh /io /io/dist travis OFF Release cp314-cp314
+        run: docker run --rm --platform linux/${{ matrix.arch == 'aarch64' && 'arm64' || 'amd64' }} -v ${{github.workspace}}/:/io ${DOCKER_IMAGE_PREFIX}_${{ matrix.arch }} sh /io/tools/package.sh /io /io/dist travis OFF Release cp314-cp314
 
       - name: Windows Package Python
         if: ${{ startsWith(matrix.os, 'windows') }}
@@ -77,7 +113,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: artifact_${{matrix.pyver}}_${{matrix.os}}
+          name: artifact_${{matrix.pyver}}_${{matrix.os}}_${{matrix.arch}}
           path: dist/*.whl
 
   publishtest:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ with one exception: GA systems have been excluded.
 
 ***
 > We now support an interface to 3.8-3.14
+> Linux wheels are available for both x86_64 and ARM64 (aarch64) architectures
 > Note that 3.10-3.14 are CentOS 7 or later while earlier versions support Centos 5 or later
 > Note: dumptext has been deprecated in favor of imaging_table and will be removed in the next version
 ***

--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -1,5 +1,11 @@
 # Changes {#changes}
 
+## v1.9.0
+
+| Date       | Description                                                 |
+|------------|-------------------------------------------------------------|
+| 2025-12-11 | Add ARM64 (aarch64) Linux wheel support for Python 3.8-3.14 |
+
 ## v1.8.0
 
 | Date       | Description                 |

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -162,8 +162,10 @@ if [  -e /opt/python ] ; then
 
           run "Test ${PYBUILD}" cmake --build $BUILD_PATH --target check -- -j${THREAD_COUNT}
           run "Build ${PYBUILD}" cmake --build $BUILD_PATH --target package_wheel -- -j${THREAD_COUNT}
-          auditwheel show ${ARTIFACT_PATH}/tmp/interop*${PYBUILD}*linux_x86_64.whl
-          auditwheel repair ${ARTIFACT_PATH}/tmp/interop*${PYBUILD}*linux_x86_64.whl -w ${ARTIFACT_PATH}
+          # Detect architecture dynamically
+          WHEEL_ARCH=$(uname -m)
+          auditwheel show ${ARTIFACT_PATH}/tmp/interop*${PYBUILD}*linux_${WHEEL_ARCH}.whl
+          auditwheel repair ${ARTIFACT_PATH}/tmp/interop*${PYBUILD}*linux_${WHEEL_ARCH}.whl -w ${ARTIFACT_PATH}
           rm -fr ${ARTIFACT_PATH}/tmp
       done
     else
@@ -183,8 +185,10 @@ if [  -e /opt/python ] ; then
 
           run "Test ${PYTHON_VERSION}" cmake --build $BUILD_PATH --target check -- -j${THREAD_COUNT}
           run "Build ${PYTHON_VERSION}" cmake --build $BUILD_PATH --target package_wheel -- -j${THREAD_COUNT}
-          auditwheel show ${ARTIFACT_PATH}/tmp/interop*${PYTHON_VERSION}*linux_x86_64.whl
-          auditwheel repair ${ARTIFACT_PATH}/tmp/interop*${PYTHON_VERSION}*linux_x86_64.whl -w ${ARTIFACT_PATH}
+          # Detect architecture dynamically
+          WHEEL_ARCH=$(uname -m)
+          auditwheel show ${ARTIFACT_PATH}/tmp/interop*${PYTHON_VERSION}*linux_${WHEEL_ARCH}.whl
+          auditwheel repair ${ARTIFACT_PATH}/tmp/interop*${PYTHON_VERSION}*linux_${WHEEL_ARCH}.whl -w ${ARTIFACT_PATH}
           rm -fr ${ARTIFACT_PATH}/tmp
     fi
 elif [ "$PYTHON_VERSION" != "" ] && [ "$PYTHON_VERSION" != "Disable" ] && [ "$PYTHON_VERSION" != "DotNetStandard" ] && [ "$PYTHON_VERSION" != "None" ] ; then


### PR DESCRIPTION
- Add ARM64 builds to GitHub Actions matrix for Python 3.8-3.14
- Configure QEMU emulation for ARM64 builds on x86_64 runners
- Use architecture-specific manylinux2014 Docker images (x86_64/aarch64)
- Update package.sh to dynamically detect architecture via uname -m
- Support both x86_64 and aarch64 wheel generation in auditwheel
- Update artifact naming to include architecture suffix
- Standardize Python 3.8 build to use manylinux images like other versions
- Update documentation (README and changelog) to reflect ARM64 support

This enables pip installation on ARM64 Linux systems including:
- AWS Graviton instances
- Raspberry Pi 4/5
- Other ARM-based cloud and edge devices

Wheels will be automatically built and published to PyPI for both architectures.